### PR TITLE
Add a vector constructor which allows a customized part.

### DIFF
--- a/vexcl/vector.hpp
+++ b/vexcl/vector.hpp
@@ -371,6 +371,16 @@ class vector : public expression {
 	    if (!host.empty()) allocate_buffers(flags, host.data());
 	}
 
+	/// Copy host data to the new buffer, with a specific part.
+	vector(const std::vector<cl::CommandQueue> &queue,
+		const std::vector<T> &host, const std::vector<size_t> &part,
+		cl_mem_flags flags = CL_MEM_READ_WRITE
+	      ) : queue(queue), part(part),
+		  buf(queue.size()), event(queue.size())
+	{
+	    if (!host.empty()) allocate_buffers(flags, host.data());
+	}
+
 	/// Move constructor
 	vector(vector &&v)
 	    : queue(std::move(v.queue)), part(std::move(v.part)),


### PR DESCRIPTION
Summary:
This constructor is important to correctly partition the variants of sparse matrix.
For example, considering the following matrix A(n*m):
0 0 0
0 1 2
0 0 0
0 0 0
3 0 4
0 0 0
As there are many empty rows, an efficient storage way for computing is:
row = [1 4]       // row numbers
idx = [0 2 4]     // pointers to col and val
col = [1 2 0 2]  // col numbers
val = [1 2 3 4]  // values

Suppose there are two dense vectors y and x, where y = A \* x.
Assuming n >> m, then to efficiently use multiple devices for y=Ax,
we need to partition y and A across multiple devices, and copy x to multiple devices.
However, we need to build A's partition scheme to align with y's.
E.g. if y is evenly partitioned in 3 devices, then,
row = [1 0](with part = {0, 1, 1, 2})
idx = [0 2 0 2](with part = {0, 2, 2, 4})
col = [1 2 0 2](with part = {0, 2, 2, 4})
val = [1 2 3 4](with part = {0, 2, 2, 4})

Denis, if my understanding is right, another potential approach is to implement a new sub class of sparse_matrix in spmat.hpp which contains row, idx, col, and val. However, the mul() doesn't support local copy of x. And also when we want to use custom kernels, things become more complex. So it seems this variant of sparse matrix doesn't fit well in current class SpMat. But correct me if I'm wrong.
