### PR TITLE
Added max(x,y) and abs(x) for vexcl vectors

### DIFF
--- a/vexcl/operations.hpp
+++ b/vexcl/operations.hpp
@@ -537,6 +537,7 @@ BUILTIN_FUNCTION_1(log10);
 BUILTIN_FUNCTION_1(log1p);
 BUILTIN_FUNCTION_1(logb);
 BUILTIN_FUNCTION_3(mad);
+BUILTIN_FUNCTION_2(max);
 BUILTIN_FUNCTION_2(maxmag);
 BUILTIN_FUNCTION_2(minmag);
 BUILTIN_FUNCTION_2(modf);
@@ -571,6 +572,28 @@ BUILTIN_FUNCTION_1(normalize);
 #undef BUILTIN_FUNCTION_1
 #undef BUILTIN_FUNCTION_2
 #undef BUILTIN_FUNCTION_3
+
+// Special case: abs() overloaded with floating point arguments should call
+// fabs in the OpenCL code
+struct abs_func : builtin_function {
+    static const char* name() {
+        return "fabs";
+    }
+};
+template <typename Arg>
+typename boost::proto::result_of::make_expr<
+    boost::proto::tag::function,
+    abs_func,
+    const Arg&
+>::type const
+abs(const Arg &arg) {
+    return boost::proto::make_expr<boost::proto::tag::function>(
+            abs_func(),
+            boost::ref(arg)
+            );
+}
+
+
 
 #define VEXCL_VECTOR_EXPR_EXTRACTOR(name, VG, AG, FG) \
 struct name \


### PR DESCRIPTION
I know fmax and fabs are already defined, but adding overloads named max and abs too was necessary for me to pass vexcl::vector to a template library that uses the cmath functions by these names.

This is an incomplete solution for abs (ideally there should be separate overloads for integral and floating point types, and only the latter should hand off to fabs in the OpenCL kernels) but it's at least a monotonic improvement in compatibility.
