### PR TITLE
Apple clang 3.1 using libc++ needs <numeric> for std::accumulate.

### DIFF
--- a/vexcl/fft/plan.hpp
+++ b/vexcl/fft/plan.hpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 #include <cmath>
 #include <queue>
+#include <numeric> //std::accumulate
 
 #include <vexcl/profiler.hpp>
 #include <vexcl/vector.hpp>


### PR DESCRIPTION
This doesn't affect me really, but using CMake to build VexCL, Clang 3.1 using libc++ (OS X version 10.8.4) needs the <numeric> header to find std::accumulate:

<pre>
[02:10:18][pbauman@Paul-Baumans-MacBook-Pro:~/my_libraries/vexcl/pbauman][fft_accumulate]$ clang++ -v
Apple clang version 4.1 (tags/Apple/clang-421.11.66) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin12.4.0
Thread model: posix
</pre>


<pre>
[  4%] Building CXX object tests/CMakeFiles/fft.dir/fft.cpp.o
cd /Users/pbauman/my_libraries/vexcl/build/tests && /usr/bin/clang++   -DBOOST_TEST_DYN_LINK -std=c++11 -stdlib=libc++ -std=c++0x -I/Users/pbauman/my_libraries/vexcl/master -I/Users/pbauman/my_libraries/boost/boost-1.54.0-clang-apple/include    -o CMakeFiles/fft.dir/fft.cpp.o -c /Users/pbauman/my_libraries/vexcl/master/tests/fft.cpp
In file included from /Users/pbauman/my_libraries/vexcl/master/tests/fft.cpp:7:
In file included from /Users/pbauman/my_libraries/vexcl/master/vexcl/fft.hpp:36:
/Users/pbauman/my_libraries/vexcl/master/vexcl/fft/plan.hpp:223:31: error: no member named 'accumulate' in namespace 'std'
        size_t total_n = std::accumulate(sizes.begin(), sizes.end(),
                         ~~~~~^
1 error generated.
make[2]: *** [tests/CMakeFiles/fft.dir/fft.cpp.o] Error 1
</pre>


This patch fixed the error.
