### PR TITLE
Set workgroup_size=1 for CPUs

### DIFF
--- a/vexcl/util.hpp
+++ b/vexcl/util.hpp
@@ -444,13 +444,17 @@ inline unsigned kernel_workgroup_size(
         const cl::Device &device
         )
 {
-    unsigned wgsz = 1024U;
+    if (is_cpu(device)) {
+        return 1U;
+    } else {
+        unsigned wgsz = 1024U;
 
-    unsigned dev_wgsz = static_cast<unsigned>(
-        kernel.getWorkGroupInfo<CL_KERNEL_WORK_GROUP_SIZE>(device));
-    while(wgsz > dev_wgsz) wgsz /= 2;
+        unsigned dev_wgsz = static_cast<unsigned>(
+                kernel.getWorkGroupInfo<CL_KERNEL_WORK_GROUP_SIZE>(device));
+        while(wgsz > dev_wgsz) wgsz /= 2;
 
-    return wgsz;
+        return wgsz;
+    }
 }
 
 /// Standard number of workgroups to launch on a device.


### PR DESCRIPTION
Another attempt to resolve #68. Work group size is set to 1 on CPUs.

Incidentally, this also increases performance on CPUs: 5 sec vs 20 sec in [lorenz attractor parameter study](https://github.com/ddemidov/gpgpu_with_modern_cpp/blob/master/src/lorenz_ensemble/vexcl_lorenz_ensemble.cpp) with ensemble of size 1024 on Intel Q9400.
