### PR TITLE
Clogs cache

### DIFF
--- a/vexcl/operations.hpp
+++ b/vexcl/operations.hpp
@@ -1793,7 +1793,7 @@ struct return_type {
 };
 
 
-// Object cache (is a map from context handle to an arbitrary object)
+// Object cache (a map from context handle to an arbitrary object)
 struct object_cache_base;
 
 template <bool dummy = true>


### PR DESCRIPTION
Queue-based cache for clogs, and a generic cache mechanism for vex. Actually the template-ness of object_cache is not used at the moment (only the kernel_cache typedef is) - let me know if I should de-template that.
