### PR TITLE
Generalization of online kernel cache.

### DIFF
--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -20,12 +20,11 @@ void local_context() {
 
     BOOST_CHECK(x.size() == n);
     BOOST_CHECK(x[0] == 0);
-
-    vex::purge_kernel_caches(ctx);
 }
 
 BOOST_AUTO_TEST_CASE(create_destroy)
 {
+    // This should work on NVIDIA GPUs with exclusive compute mode.
     local_context();
     local_context();
 }

--- a/vexcl/backend/cuda/context.hpp
+++ b/vexcl/backend/cuda/context.hpp
@@ -257,13 +257,31 @@ struct ndrange {
 };
 
 /// \cond INTERNAL
-/// A unique context id that is used for online kernel caching.
-typedef CUcontext kernel_cache_key;
+typedef CUcontext context_id;
 
-/// Returns kernel cache key for the given queue.
-inline kernel_cache_key cache_key(const command_queue &q) {
+/// Returns raw context id for the given queue.
+inline context_id get_context_id(const command_queue &q) {
     return q.context().raw();
 }
+
+/// Returns context for the given queue.
+inline context get_context(const command_queue &q) {
+    return q.context();
+}
+
+/// Compares contexts by raw ids.
+struct compare_contexts {
+    bool operator()(const context &a, const context &b) const {
+        return a.raw() < b.raw();
+    }
+};
+
+/// Compares queues by raw ids.
+struct compare_queues {
+    bool operator()(const command_queue &a, const command_queue &b) const {
+        return a.raw() < b.raw();
+    }
+};
 /// \endcond
 
 /// Create command queue on the same context and device as the given one.

--- a/vexcl/backend/cuda/cusparse.hpp
+++ b/vexcl/backend/cuda/cusparse.hpp
@@ -69,9 +69,9 @@ struct deleter_impl<cusparseHybMat_t> {
 
 inline cusparseHandle_t cusparse_handle(const command_queue &q) {
     typedef std::shared_ptr<std::remove_pointer<cusparseHandle_t>::type> smart_handle;
-    static std::map< kernel_cache_key, smart_handle > cache;
+    static std::map< backend::context_id, smart_handle > cache;
 
-    auto key = cache_key(q);
+    auto key = backend::get_context_id(q);
     auto h   = cache.find(key);
 
     if (h == cache.end()) {

--- a/vexcl/backend/opencl/context.hpp
+++ b/vexcl/backend/opencl/context.hpp
@@ -66,11 +66,30 @@ inline device_id get_device_id(const command_queue &q) {
 }
 
 /// \cond INTERNAL
-typedef cl_context                  kernel_cache_key;
-/// Returns kernel cache key for the given queue.
-inline kernel_cache_key cache_key(const command_queue &q) {
+typedef cl_context       context_id;
+/// Returns raw context id for the given queue.
+inline context_id get_context_id(const command_queue &q) {
     return q.getInfo<CL_QUEUE_CONTEXT>()();
 }
+
+/// Returns context for the given queue.
+inline context get_context(const command_queue &q) {
+    return q.getInfo<CL_QUEUE_CONTEXT>();
+}
+
+/// Compares contexts by raw ids.
+struct compare_contexts {
+    bool operator()(const context &a, const context &b) const {
+        return a() < b();
+    }
+};
+
+/// Compares queues by raw ids.
+struct compare_queues {
+    bool operator()(const command_queue &a, const command_queue &b) const {
+        return a() < b();
+    }
+};
 /// \endcond
 
 /// Create command queue on the same context and device as the given one.

--- a/vexcl/cache.hpp
+++ b/vexcl/cache.hpp
@@ -1,0 +1,174 @@
+#ifndef VEXCL_CACHE_HPP
+#define VEXCL_CACHE_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2014 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   vexcl/cache.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  Generic online cache implementation.
+ */
+
+#include <set>
+#include <map>
+
+#include <boost/utility.hpp>
+
+#include <vexcl/backend.hpp>
+
+namespace vex {
+namespace detail {
+
+// Abstract base class for object cache.
+struct object_cache_base;
+
+// List of all active caches.
+template <bool dummy = true>
+struct cache_register {
+    static_assert(dummy, "Dummy parameter should be true");
+
+    static std::set<object_cache_base*> caches;
+
+    static void add(object_cache_base *cache) {
+        caches.insert(cache);
+    }
+
+    static void remove(object_cache_base *cache) {
+        caches.erase(cache);
+    }
+
+    static void clear();
+    static void erase(const backend::command_queue &q);
+};
+
+template <bool dummy>
+std::set<object_cache_base*> cache_register<dummy>::caches;
+
+// Abstract base class for object cache.
+struct object_cache_base {
+    virtual void clear() = 0;
+    virtual void erase(const backend::command_queue &q) = 0;
+    virtual ~object_cache_base() {}
+};
+
+template <bool dummy>
+void cache_register<dummy>::clear() {
+    for(auto c = caches.begin(); c != caches.end(); ++c)
+        (*c)->clear();
+}
+
+template <bool dummy>
+void cache_register<dummy>::erase(const backend::command_queue &q) {
+    for(auto c = caches.begin(); c != caches.end(); ++c)
+        (*c)->erase(q);
+}
+
+// Indexes cache objects by context
+struct index_by_context {
+    typedef backend::context          type;
+    typedef backend::compare_contexts compare;
+
+    static type get(const backend::command_queue &q) {
+        return backend::get_context(q);
+    }
+};
+
+// Indexes cache objects by command queue
+struct index_by_queue {
+    typedef backend::command_queue  type;
+    typedef backend::compare_queues compare;
+
+    static type get(const backend::command_queue &q) {
+        return q;
+    }
+};
+
+// Online cache. Stores Objects indexed by Key::type.
+// Note that from the user standpoint everything is indexed by
+// `const backend::command_queue&`.
+template <class Key, class Object>
+struct object_cache : public object_cache_base, boost::noncopyable {
+    typedef std::map<typename Key::type, Object, typename Key::compare> store_type;
+
+    store_type store;
+
+    object_cache() {
+        cache_register<true>::add(this);
+    }
+
+    ~object_cache() {
+        cache_register<true>::remove(this);
+    }
+
+    template <class I>
+    typename store_type::iterator
+    insert(const backend::command_queue &q, I &&item) {
+        return store.insert( std::make_pair(
+                    Key::get(q), std::forward<I>(item)
+                    ) ).first;
+    }
+
+    typename store_type::const_iterator end() const {
+        return store.end();
+    }
+
+    typename store_type::iterator find(const backend::command_queue &q) {
+        return store.find( Key::get(q) );
+    }
+
+    void clear() {
+        store.clear();
+    }
+
+    void erase(const backend::command_queue &q) {
+        store.erase( Key::get(q) );
+    }
+};
+
+// The most common type of object cache is kernel cache:
+typedef object_cache<index_by_context, backend::kernel> kernel_cache;
+
+}
+
+/// Clears cached objects, allowing to cleanly release contexts.
+inline void purge_caches() {
+    detail::cache_register<true>::clear();
+}
+
+/// Clears cached objects, allowing to cleanly release contexts.
+inline void purge_caches(const backend::command_queue &q) {
+    detail::cache_register<true>::erase(q);
+}
+
+/// Clears cached objects, allowing to cleanly release contexts.
+inline void purge_caches(const std::vector<backend::command_queue> &queue) {
+    for(auto q = queue.begin(); q != queue.end(); ++q)
+        detail::cache_register<true>::erase( *q );
+}
+
+}
+
+
+#endif

--- a/vexcl/devlist.hpp
+++ b/vexcl/devlist.hpp
@@ -310,7 +310,7 @@ class Context {
         }
 
         ~Context() {
-            purge_kernel_caches(q);
+            purge_caches(q);
         }
 
         const std::vector<backend::context>& context() const {

--- a/vexcl/generator.hpp
+++ b/vexcl/generator.hpp
@@ -549,7 +549,7 @@ class Kernel {
 
                 backend::select_context(*q);
                 cache.insert(std::make_pair(
-                            backend::cache_key(*q),
+                            backend::get_context_id(*q),
                             backend::kernel(*q, source.str(), name.c_str())
                             ));
             }
@@ -585,7 +585,7 @@ BOOST_PP_REPEAT_FROM_TO(1, VEXCL_MAX_ARITY, VEXCL_FUNCALL_OPERATOR, ~)
 
             for(unsigned d = 0; d < queue.size(); d++) {
                 if (size_t psize = boost::fusion::fold(param, 0, param_size(d))) {
-                    auto key = backend::cache_key(queue[d]);
+                    auto key = backend::get_context_id(queue[d]);
                     auto krn = cache.find(key);
                     krn->second.push_arg(psize);
 
@@ -649,10 +649,7 @@ BOOST_PP_REPEAT_FROM_TO(1, VEXCL_MAX_ARITY, VEXCL_FUNCALL_OPERATOR, ~)
 
         std::vector<backend::command_queue> queue;
 
-        std::map<
-            vex::backend::kernel_cache_key,
-            vex::backend::kernel
-            > cache;
+        std::map<vex::backend::context_id, vex::backend::kernel> cache;
 
         struct param_size {
             unsigned device;

--- a/vexcl/reduce_by_key.hpp
+++ b/vexcl/reduce_by_key.hpp
@@ -65,8 +65,7 @@ template <typename T, class Comp>
 backend::kernel offset_calculation(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -95,8 +94,8 @@ backend::kernel offset_calculation(const backend::command_queue &queue) {
         src.close("}");
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "offset_calculation");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "offset_calculation"));
     }
 
     return kernel->second;
@@ -107,8 +106,7 @@ template <int NT, typename T, class Oper>
 backend::kernel block_scan_by_key(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -179,8 +177,8 @@ backend::kernel block_scan_by_key(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_scan_by_key");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_scan_by_key"));
     }
 
     return kernel->second;
@@ -192,8 +190,7 @@ backend::kernel block_inclusive_scan_by_key(const backend::command_queue &queue)
 {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -305,8 +302,8 @@ backend::kernel block_inclusive_scan_by_key(const backend::command_queue &queue)
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_inclusive_scan_by_key");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_inclusive_scan_by_key"));
     }
 
     return kernel->second;
@@ -317,8 +314,7 @@ template <typename T, class Oper>
 backend::kernel block_sum_by_key(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -353,8 +349,8 @@ backend::kernel block_sum_by_key(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_sum_by_key");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_sum_by_key"));
     }
 
     return kernel->second;
@@ -365,8 +361,7 @@ template <typename K, typename V>
 backend::kernel key_value_mapping(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -406,8 +401,8 @@ backend::kernel key_value_mapping(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "key_value_mapping");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "key_value_mapping"));
     }
 
     return kernel->second;

--- a/vexcl/scan.hpp
+++ b/vexcl/scan.hpp
@@ -68,8 +68,7 @@ backend::kernel block_inclusive_scan(const backend::command_queue &queue)
 {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -137,8 +136,8 @@ backend::kernel block_inclusive_scan(const backend::command_queue &queue)
         src.close("}");
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_inclusive_scan");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_inclusive_scan"));
     }
 
     return kernel->second;
@@ -149,8 +148,7 @@ backend::kernel intra_block_inclusive_scan(const backend::command_queue &queue)
 {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -240,8 +238,8 @@ backend::kernel intra_block_inclusive_scan(const backend::command_queue &queue)
         src.close("}");
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "intra_block_inclusive_scan");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "intra_block_inclusive_scan"));
     }
 
     return kernel->second;
@@ -254,8 +252,7 @@ backend::kernel block_addition(
 {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -330,8 +327,8 @@ backend::kernel block_addition(
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_addition");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_addition"));
     }
 
     return kernel->second;

--- a/vexcl/sort.hpp
+++ b/vexcl/sort.hpp
@@ -814,8 +814,7 @@ template <int NT, int VT, typename K, typename V, typename Comp>
 backend::kernel& block_sort_kernel(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -951,8 +950,8 @@ backend::kernel& block_sort_kernel(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "block_sort");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "block_sort"));
     }
 
     return kernel->second;
@@ -988,8 +987,7 @@ template <int NT, typename T, typename Comp>
 backend::kernel merge_partition_kernel(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -1043,8 +1041,8 @@ backend::kernel merge_partition_kernel(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "merge_partition");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "merge_partition"));
     }
 
     return kernel->second;
@@ -1673,8 +1671,7 @@ template <int NT, int VT, typename K, typename V, typename Comp>
 backend::kernel merge_kernel(const backend::command_queue &queue) {
     static detail::kernel_cache cache;
 
-    auto cache_key = backend::cache_key(queue);
-    auto kernel    = cache.find(cache_key);
+    auto kernel = cache.find(queue);
 
     if (kernel == cache.end()) {
         backend::source_generator src(queue);
@@ -1760,8 +1757,8 @@ backend::kernel merge_kernel(const backend::command_queue &queue) {
 
         src.close("}");
 
-        backend::kernel krn(queue, src.str(), "merge");
-        kernel = cache.insert(std::make_pair(cache_key, krn)).first;
+        kernel = cache.insert(queue, backend::kernel(
+                    queue, src.str(), "merge"));
     }
 
     return kernel->second;

--- a/vexcl/spmat/csr.inl
+++ b/vexcl/spmat/csr.inl
@@ -143,8 +143,7 @@ struct SpMatCSR : public sparse_matrix {
 
         static kernel_cache cache;
 
-        auto key    = backend::cache_key(queue);
-        auto kernel = cache.find(key);
+        auto kernel = cache.find(queue);
 
         backend::select_context(queue);
 
@@ -171,8 +170,8 @@ struct SpMatCSR : public sparse_matrix {
             source.new_line() << "out[i] " << OP::string() << " scale * sum;";
             source.close("}").close("}");
 
-            backend::kernel krn(queue, source.str(), "csr_spmv");
-            kernel = cache.insert(std::make_pair(key, krn)).first;
+            kernel = cache.insert(queue, backend::kernel(
+                        queue, source.str(), "csr_spmv"));
         }
 
         kernel->second.push_arg(n);

--- a/vexcl/spmat/hybrid_ell.inl
+++ b/vexcl/spmat/hybrid_ell.inl
@@ -228,8 +228,7 @@ struct SpMatHELL : public sparse_matrix {
 
         static kernel_cache cache;
 
-        auto key    = backend::cache_key(queue);
-        auto kernel = cache.find(key);
+        auto kernel = cache.find(queue);
 
         backend::select_context(queue);
 
@@ -269,8 +268,8 @@ struct SpMatHELL : public sparse_matrix {
             source.new_line() << "out[i] " << OP::string() << " scale * sum;";
             source.close("}").close("}");
 
-            backend::kernel krn(queue, source.str(), "hybrid_ell_spmv");
-            kernel = cache.insert(std::make_pair(key, krn)).first;
+            kernel = cache.insert(queue, backend::kernel(
+                        queue, source.str(), "hybrid_ell_spmv"));
         }
 
         kernel->second.push_arg(n);


### PR DESCRIPTION
This is an extension of idea proposed by @bmerry in #117.
Basically, kernel_cache now is an instantiation of object_cache class
template. The object_cache may hold objects of any kind, indexed by
either `context_id` or `command_queue_id`. From the user standpoint though
the indexing is always happening by `const backend::command_queue&`.

All caches may be transparently purged by `purge_kernel_caches()` family
of functions.
