### PR TITLE
added constant pointer qualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Other talks may be found at
     * [Element indices](#element-indices)
     * [User-defined functions](#user-defined-functions)
     * [Tagged terminals](#tagged-terminals)
+    * [Pointer qualifiers](#pointer-qualifiers)
     * [Temporary values](#temporary-values)
     * [Random number generation](#random-number-generation)
     * [Permutations](#permutations)
@@ -51,6 +52,7 @@ Other talks may be found at
 * [Sparse matrix-vector products](#sparse-matrix-vector-products)
 * [Stencil convolutions](#stencil-convolutions)
 * [Raw pointers](#raw-pointers)
+* [Pointers to constant vector](#pointers-to-constant-vector)
 * [Sort, scan, reduce-by-key algorithms](#parallel-primitives)
 * [Multivectors](#multivectors)
 * [Converting generic C++ algorithms to OpenCL/CUDA](#converting-generic-c-algorithms-to-opencl)
@@ -375,6 +377,15 @@ Z = sqrt(tag<1>(X) * tag<1>(X) + tag<2>(Y) * tag<2>(Y));
 ~~~
 Here, the generated kernel will have one parameter for each of the vectors `X`
 and `Y`.
+
+### <a name="pointer-qualifiers"></a>Pointer qualifiers
+
+To optimise the code the programmer can use pointer qualifiers.
+At the moment the 'constant' qualifier is implemented. The qualifier will set the variable into a separate memoryspace.
+This memoryspace is a separate cache and is as fast as the local memory. The cache size is vendor dependent but has to
+be atleast 64kB for openCL devices.
+For example if you need to add two small vectors. <32kB each.
+s = constant(x) + constant(y);
 
 ### <a name="temporary-values"></a>Temporary values
 
@@ -819,6 +830,16 @@ y = global_interaction(x.size(), vex::element_index(), vex::raw_pointer(x));
 Note that the use of `raw_pointer()` is limited to single-device contexts for
 obvious reasons.
 
+## <a name="pointers-to-constant-vector"></a>Pointers to constant vector
+These special kind of pointers are exactly the same as a raw pointer, but they point to objects in the constant
+memoryspace instead of the global memoryspace. These vectors have a maximum size defined by the manufacturer.
+The constant memoryspace is atleast 64kB in size for openCL devices.
+one could for example cache some logarithmic math instead of calculating it.
+
+~~~{.cpp}
+ptrLogVector=constant_pointer(logVector);
+s = logVector[IntVector];
+~~~
 ## <a name="parallel-primitives"></a>Sort, scan, reduce-by-key algorithms
 
 VexCL provides several standalone parallel primitives that may not be used as

--- a/tests/vector_arithmetics.cpp
+++ b/tests/vector_arithmetics.cpp
@@ -9,6 +9,7 @@
 #include <vexcl/element_index.hpp>
 #include <vexcl/tagged_terminal.hpp>
 #include <vexcl/function.hpp>
+#include <vexcl/pointer_qualifiers.hpp>
 #include <boost/math/constants/constants.hpp>
 #include "context_setup.hpp"
 
@@ -281,6 +282,23 @@ BOOST_AUTO_TEST_CASE(constants)
 
     x = vex::constants::pi();
     check_sample(x, [](size_t, double v) { BOOST_CHECK_CLOSE(v, boost::math::constants::pi<double>(), 1e-8); });
+}
+
+BOOST_AUTO_TEST_CASE(constant)
+{
+    const size_t N = 1024;
+
+    vex::vector<double> x(ctx, N);
+    vex::vector<double> y(ctx, N);
+    vex::vector<double> z(ctx, N);
+
+    y = 42;
+    z = 67;
+    x = 5 * sin(vex::constant(y)) + vex::constant(z);
+
+    check_sample(x, [](size_t, double a) {
+            BOOST_CHECK_CLOSE(a, 5 * sin(42.0) + 67, 1e-12);
+            });
 }
 
 #if (VEXCL_CHECK_SIZES > 0)

--- a/tests/vector_pointer.cpp
+++ b/tests/vector_pointer.cpp
@@ -80,5 +80,48 @@ BOOST_AUTO_TEST_CASE(manual_stencil)
             });
 }
 
+BOOST_AUTO_TEST_CASE(manual_stencil_constant)
+{
+    const size_t n = 1024;
+
+    std::vector<vex::command_queue> queue(1, ctx.queue(0));
+
+    std::vector<double> X = random_vector<double>(n);
+
+    vex::vector<double> x(queue, X);
+    vex::vector<double> y(queue, n);
+
+    VEX_CONSTANT(nil, 0);
+    VEX_CONSTANT(one, 1);
+    VEX_CONSTANT(two, 2);
+
+    auto N = vex::tag<1>( x.size() );
+    auto p = vex::constant_pointer(x);
+
+    auto i     = vex::make_temp<1>( vex::element_index() );
+    auto left  = vex::make_temp<2>( if_else(i > nil(), i - one(), i ) );
+    auto right = vex::make_temp<3>( if_else(i + one() < N, i + one(), i ) );
+
+    // Use pointer arithmetics
+    y = *(p + i) * two() - *(p + left) - *(p + right);
+
+    check_sample(y, [&](size_t idx, double v) {
+            double xc = X[idx];
+            double xl = X[idx > 0 ? idx - 1 : idx];
+            double xr = X[idx + 1 < n ? idx + 1 : idx];
+            BOOST_CHECK_CLOSE(v, 2 * xc - xr - xl, 1e-8);
+            });
+
+    // Same thing with index operators
+    y = p[i] * two() - p[left] - p[right];
+
+    check_sample(y, [&](size_t idx, double v) {
+            double xc = X[idx];
+            double xl = X[idx > 0 ? idx - 1 : idx];
+            double xr = X[idx + 1 < n ? idx + 1 : idx];
+            BOOST_CHECK_CLOSE(v, 2 * xc - xr - xl, 1e-8);
+            });
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/vexcl/backend/cuda/source.hpp
+++ b/vexcl/backend/cuda/source.hpp
@@ -47,12 +47,15 @@ namespace vex {
 template <class T> struct global_ptr {};
 template <class T> struct shared_ptr {};
 template <class T> struct regstr_ptr {};
+template <class T> struct constant_ptr {};
 
 template <class T> struct remove_ptr;
 
 template <class T> struct remove_ptr< global_ptr<T> > { typedef T type; };
 template <class T> struct remove_ptr< shared_ptr<T> > { typedef T type; };
 template <class T> struct remove_ptr< regstr_ptr<T> > { typedef T type; };
+template <class T> struct remove_ptr< constant_ptr<T> > { typedef T type; };
+
 
 template <class T>
 struct type_name_impl <global_ptr<T> > {
@@ -83,6 +86,32 @@ struct type_name_impl <regstr_ptr<T> > : type_name_impl< global_ptr<T> > { };
 
 template <class T>
 struct type_name_impl <regstr_ptr<const T> > : type_name_impl< global_ptr<const T> > { };
+
+
+//constant variables are not the same as const variables.
+//constant variables tends to end up in a constant cache which is as fast as local memory or even faster.
+//const is just read only
+template <class T>
+struct type_name_impl <constant_ptr<T> > {
+	static std::string get() {
+		std::ostringstream s;
+		s << "__constant__ " << type_name<T>() << " *";
+		return s.str();
+	}
+};
+
+template <class T>
+struct type_name_impl < constant_ptr<const T> > {
+	static std::string get() {
+		std::ostringstream s;
+		s << "__constant__ " << type_name<T>() << " *";
+		return s.str();
+	}
+};
+
+
+
+
 
 template<typename T>
 struct type_name_impl<T*>

--- a/vexcl/backend/opencl/source.hpp
+++ b/vexcl/backend/opencl/source.hpp
@@ -47,12 +47,14 @@ namespace vex {
 template <class T> struct global_ptr {};
 template <class T> struct shared_ptr {};
 template <class T> struct regstr_ptr {};
+template <class T> struct constant_ptr {};
 
 template <class T> struct remove_ptr;
 
 template <class T> struct remove_ptr< global_ptr<T> > { typedef T type; };
 template <class T> struct remove_ptr< shared_ptr<T> > { typedef T type; };
 template <class T> struct remove_ptr< regstr_ptr<T> > { typedef T type; };
+template <class T> struct remove_ptr< constant_ptr<T> > { typedef T type; };
 
 template <class T>
 struct type_name_impl <global_ptr<T> > {
@@ -107,6 +109,29 @@ struct type_name_impl <regstr_ptr<const T> > {
         return s.str();
     }
 };
+
+//constant is not the same as const.
+//constant variables tends to end up in a constant cache which is as fast as local memory or even faster.
+//const is just read only
+template <class T>
+struct type_name_impl <constant_ptr<T> > {
+	static std::string get() {
+		std::ostringstream s;
+		s << "constant " <<type_name<T>() << " *";
+		return s.str();
+	}
+};
+
+template <class T>
+struct type_name_impl <constant_ptr<const T> > {
+	static std::string get() {
+		std::ostringstream s;
+		s << "constant " << type_name<T>() << " *";
+		return s.str();
+	}
+};
+
+
 
 template<typename T>
 struct type_name_impl<T*>

--- a/vexcl/pointer_qualifiers.hpp
+++ b/vexcl/pointer_qualifiers.hpp
@@ -1,0 +1,147 @@
+#ifndef VEXCL_POINTER_QUALIFIERS_HPP
+#define VEXCL_POINTER_QUALIFIERS_HPP
+/*
+The MIT License
+
+Copyright (c) 2012-2015 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   vexcl/backend/opencl/source.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  Helper class for OpenCL source code generation.
+ */
+
+
+#include <vexcl/operations.hpp>
+
+namespace vex {
+	/// \cond INTERNAL
+	//_________________________________________________ constant keyword
+	// The struct will be used as an identificator of constant vector
+	// expressions.
+	struct constant_vector_terminal {};
+
+	// Introduce the new kind of expression to Boost.Proto.
+	typedef vector_expression<
+	typename boost::proto::terminal< constant_vector_terminal >::type
+	> constant_vector_expression;
+
+	// The actual terminal.
+	// This struct will hold a reference to a vector that needs to be declared with
+	// 'restrict' qualifier.
+	template <class T>
+	struct constant_vector : constant_vector_expression {
+		typedef T value_type; // has to be here for vex::deduce() to work with constant vectors.
+		const vector<T> &v;
+		constant_vector(const vector<T> &v) : v(v) {}
+	};
+
+
+
+	// Code generation helpers.
+	namespace traits {
+
+		// Tell proto it is ok to use these terminals in vexcl expressions.
+		template <>
+		struct is_vector_expr_terminal< constant_vector_terminal > : std::true_type {};
+
+		// Tell proto that it is not required to unpack the terminal with
+		// proto::value() function.
+		template <>
+		struct proto_terminal_is_value< constant_vector_terminal > : std::true_type {};
+
+		// Declare kernel parameter for the constant vector.
+		// This is the only specification that is different from vector<T>.
+		template <typename T>
+		struct kernel_param_declaration< constant_vector<T> > {
+			static void get(backend::source_generator &src,
+							const constant_vector<T>&,
+							const backend::command_queue&, const std::string &prm_name,
+							detail::kernel_generator_state_ptr)
+			{
+
+				src.parameter< constant_ptr<T> >( prm_name);
+
+			}
+		};
+
+		// The following specifications just delegate the work to vector<T>:
+		template <typename T>
+		struct partial_vector_expr< constant_vector<T> > {
+			static void get(backend::source_generator &src,
+							const constant_vector<T> &rv,
+							const backend::command_queue &q, const std::string &prm_name,
+							detail::kernel_generator_state_ptr state)
+			{
+				get_partial_vector_expr(src, rv.v, q, prm_name, state);
+			}
+		};
+
+		template <typename T>
+		struct kernel_arg_setter< constant_vector<T> > {
+			static void set(const constant_vector<T> &rv,
+							backend::kernel &kernel, unsigned device, size_t index_offset,
+							detail::kernel_generator_state_ptr state)
+			{
+				set_kernel_args(rv.v, kernel, device, index_offset, state);
+			}
+		};
+
+		template <class T>
+		struct expression_properties< constant_vector<T> > {
+			static void get(const constant_vector<T> &rv,
+							std::vector<backend::command_queue> &queue_list,
+							std::vector<size_t> &partition,
+							size_t &size
+							)
+			{
+				extract_expression_properties(rv.v, queue_list, partition, size);
+			}
+		};
+
+	} // namespace traits
+/// \endcond
+/// Pointer Qualifiers
+/**
+* VexCL allowes you to set pointer qualifiers to tell the compiler to put your code in constant memory space.
+* This memory space is faster than global memory and as fast or faster than local memory.
+* But the size of this chache is limited.
+* These qualifiers can be set by using vex::constant,
+* constant type * or __constant__ type * for cuda.
+* For example if you need to add two small vectors. <32kB each.
+\code
+s = constant(x) + constant(y);
+\endcode
+*/
+	template <class T>
+	inline constant_vector<T> constant(const vector<T> &v) {
+		return constant_vector<T>(v);
+	}
+
+
+} // namespace vex
+
+
+
+
+
+#endif // VEXCL_POINTER_QUALIFIERS_HPP

--- a/vexcl/vector_pointer.hpp
+++ b/vexcl/vector_pointer.hpp
@@ -45,6 +45,7 @@ struct vector_pointer {
     vector_pointer(const vector<T> &v) : v(v) {}
 };
 
+
 /// Cast vex::vector to a raw pointer.
 /**
  * Useful when user wants to get a pointer to a vector instead of its current
@@ -66,6 +67,8 @@ raw_pointer(const vector<T> &v) {
 
     return boost::proto::as_expr<vector_domain>(vector_pointer<T>(v));
 }
+
+
 
 namespace traits {
 
@@ -110,6 +113,86 @@ struct expression_properties< vector_pointer<T> >
     }
 };
 
+} // namespace traits
+
+
+template <typename T>
+struct constant_vector_pointer {
+	typedef T value_type;
+
+	const vector<T> &v;
+
+	constant_vector_pointer(const vector<T> &v) : v(v) {}
+};
+
+/// Cast vex::vector to a constant pointer.
+/**
+ * Useful when user wants to get a pointer to a constant vector instead of its current
+ * element inside a vector expression. Could be combined with calls to
+ * address_of/dereference operators or with user-defined functions iterating
+ * through the constant vector. This vector is atleast 64kB in size as defined by the openCL standard.
+ *one could for example cache some logarithmic math instead of calculating it.
+\code
+ptrLogVector=constant_pointer(logVector);
+s = logVector[IntVector];
+\endcode
+ */
+template <typename T>
+#ifdef DOXYGEN
+constant_vector_pointer<T>
+#else
+inline typename boost::proto::result_of::as_expr<constant_vector_pointer<T>, vector_domain>::type
+#endif
+constant_pointer(const vector<T> &v) {
+	precondition(
+				v.nparts() == 1,
+				"raw_pointer is not supported for multi-device contexts"
+				);
+
+	return boost::proto::as_expr<vector_domain>(constant_vector_pointer<T>(v));
+}
+
+namespace traits {
+	template <typename T>
+	struct is_vector_expr_terminal< constant_vector_pointer<T> > : std::true_type {};
+
+	template <typename T>
+	struct kernel_param_declaration< constant_vector_pointer<T> >
+	{
+		static void get(backend::source_generator &src,
+						const constant_vector_pointer<T>&,
+						const backend::command_queue&, const std::string &prm_name,
+						detail::kernel_generator_state_ptr)
+		{
+			src.parameter< constant_ptr<T> >(prm_name);
+		}
+	};
+
+	template <typename T>
+	struct kernel_arg_setter< constant_vector_pointer<T> >
+	{
+		static void set(const constant_vector_pointer<T> &term,
+						backend::kernel &kernel, unsigned/*part*/, size_t/*index_offset*/,
+						detail::kernel_generator_state_ptr)
+		{
+			kernel.push_arg(term.v(0));
+		}
+	};
+
+	template <typename T>
+	struct expression_properties< constant_vector_pointer<T> >
+	{
+		static void get(const constant_vector_pointer<T> &term,
+						std::vector<backend::command_queue> &queue_list,
+						std::vector<size_t> &partition,
+						size_t &/*size*/
+						)
+		{
+			queue_list = term.v.queue_list();
+			partition  = term.v.partition();
+			// Raw pointers should not have size.
+		}
+	};
 } // namespace traits
 }
 

--- a/vexcl/vexcl.hpp
+++ b/vexcl/vexcl.hpp
@@ -60,5 +60,6 @@ THE SOFTWARE.
 #include <vexcl/profiler.hpp>
 #include <vexcl/function.hpp>
 #include <vexcl/logical.hpp>
+#include <vexcl/pointer_qualifiers.hpp>
 
 #endif


### PR DESCRIPTION
since i had to update yto your new master and it was easier to just do a "hard reset" and start over again i have had to make a new pull request. 

The qualifier allows you to set an vector as a 'constant' if this vector is smaller than 64kB it will end up in the constant cache. But i think it has to be used in combination of a raw pointer to be really useful. For example if you want to multiply a small vector with a large one. Or it might be useful for a multiple dimension vector where you do an operation between a small constant vector and each vector of the multidimensional vector. 
~~~{.cpp}
Y = X*constant(Z[index/cycleConstant]);
~~~