### PR TITLE
Suppress OpenCL 2.0 deprecation warnings in the OpenCL 1.2 C++ Wrapper API.

### DIFF
--- a/vexcl/backend/opencl.hpp
+++ b/vexcl/backend/opencl.hpp
@@ -38,6 +38,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 #include <vexcl/backend/opencl/error.hpp>

--- a/vexcl/backend/opencl/compiler.hpp
+++ b/vexcl/backend/opencl/compiler.hpp
@@ -41,6 +41,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 namespace vex {

--- a/vexcl/backend/opencl/context.hpp
+++ b/vexcl/backend/opencl/context.hpp
@@ -37,6 +37,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 namespace vex {

--- a/vexcl/backend/opencl/device_vector.hpp
+++ b/vexcl/backend/opencl/device_vector.hpp
@@ -34,6 +34,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 namespace vex {

--- a/vexcl/backend/opencl/error.hpp
+++ b/vexcl/backend/opencl/error.hpp
@@ -36,6 +36,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 namespace vex {

--- a/vexcl/backend/opencl/filter.hpp
+++ b/vexcl/backend/opencl/filter.hpp
@@ -45,6 +45,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 

--- a/vexcl/backend/opencl/kernel.hpp
+++ b/vexcl/backend/opencl/kernel.hpp
@@ -36,6 +36,9 @@ THE SOFTWARE.
 #ifndef __CL_ENABLE_EXCEPTIONS
 #  define __CL_ENABLE_EXCEPTIONS
 #endif
+#ifndef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#endif
 #include <CL/cl.hpp>
 
 #include <vexcl/backend/opencl/compiler.hpp>


### PR DESCRIPTION
As the C++ wrapper API is indeed valuable boilerplate, just silence the warnings.
Hopefully cl.hpp will get an update soon:
https://www.khronos.org/message_boards/showthread.php/9651-Official-OpenCL-2-1-Feedback-thread?p=31343#post31343
