### PR TITLE
Make boost libs required in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (MSVC10)
     set(VEXCL_BOOST_COMPONENTS ${VEXCL_BOOST_COMPONENTS} chrono)
 endif ()
 
-find_package(Boost COMPONENTS ${VEXCL_BOOST_COMPONENTS})
+find_package(Boost REQUIRED COMPONENTS ${VEXCL_BOOST_COMPONENTS})
 
 include_directories( ${Boost_INCLUDE_DIRS} )
 


### PR DESCRIPTION
Pull request for the change in CMakeLists.txt on line 83 that will make boost libs required by CMake, as discussed in issue #179.