### PR TITLE
directive when including cl_platform

### DIFF
--- a/vexcl/types.hpp
+++ b/vexcl/types.hpp
@@ -41,7 +41,11 @@ THE SOFTWARE.
 #include <boost/io/ios_state.hpp>
 
 // This should be available for all backends
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl_platform.h>
+#else
 #include <CL/cl_platform.h>
+#endif
 
 /// \cond INTERNAL
 typedef unsigned int  uint;


### PR DESCRIPTION
@ddemidov This PR provides a needed directive when using vexcl on osx. It seems that opencl, as including on osx, lives in a different directory.

Do you know how others on OSX have compiled vexcl without this?