### PR TITLE
Use vex::CombineReductors<RDC1, RDC2, ...> to make multiple reductions in one pass

### DIFF
--- a/tests/vector_arithmetics.cpp
+++ b/tests/vector_arithmetics.cpp
@@ -74,6 +74,13 @@ BOOST_AUTO_TEST_CASE(reduce_expression)
     BOOST_CHECK_EQUAL(min(X), *std::min_element(x.begin(), x.end()));
     BOOST_CHECK_EQUAL(max(X), *std::max_element(x.begin(), x.end()));
 
+#ifndef BOOST_NO_VARIADIC_TEMPLATES
+    vex::Reductor<double,vex::MIN_MAX  > minmax(ctx);
+    auto mm = minmax(X);
+    BOOST_CHECK_EQUAL(mm.s[0], *std::min_element(x.begin(), x.end()));
+    BOOST_CHECK_EQUAL(mm.s[1], *std::max_element(x.begin(), x.end()));
+#endif
+
     BOOST_CHECK_EQUAL( max( fabs(X - X) ), 0.0);
 }
 

--- a/vexcl/reductor.hpp
+++ b/vexcl/reductor.hpp
@@ -49,16 +49,20 @@ struct SUM {
     // a struct like the following:
     template <class T>
     struct impl {
+        typedef T result_type;
+
         // Initial value for the operation.
         static T initial() {
             return T();
         }
 
         // Device-side reduction function.
-        struct device : UserFunction<device, T(T, T)> {
+        struct device_in : UserFunction<device_in, T(T, T)> {
             static std::string name() { return "SUM_" + type_name<T>(); }
             static std::string body() { return "return prm1 + prm2;"; }
         };
+
+        typedef device_in device_out;
 
         // Host-side reduction function.
         T operator()(T a, T b) const {
@@ -79,6 +83,8 @@ struct SUM_Kahan : SUM {};
 struct MAX {
     template <class T>
     struct impl {
+        typedef T result_type;
+
         // Initial value for the operation.
         static T initial() {
 #ifdef _MSC_VER
@@ -94,10 +100,12 @@ struct MAX {
 #endif
         }
 
-        struct device : UserFunction<device, T(T, T)> {
+        struct device_in : UserFunction<device_in, T(T, T)> {
             static std::string name() { return "MAX_" + type_name<T>(); }
             static std::string body() { return "return prm1 > prm2 ? prm1 : prm2;"; }
         };
+
+        typedef device_in device_out;
 
         T operator()(T a, T b) const {
             return a > b ? a : b;
@@ -109,15 +117,19 @@ struct MAX {
 struct MIN {
     template <class T>
     struct impl {
+        typedef T result_type;
+
         // Initial value for the operation.
         static T initial() {
             return std::numeric_limits<T>::max();
         }
 
-        struct device : UserFunction<device, T(T, T)> {
+        struct device_in : UserFunction<device_in, T(T, T)> {
             static std::string name() { return "MIN_" + type_name<T>(); }
             static std::string body() { return "return prm1 < prm2 ? prm1 : prm2;"; }
         };
+
+        typedef device_in device_out;
 
         T operator()(T a, T b) const {
             return a < b ? a : b;
@@ -125,52 +137,324 @@ struct MIN {
     };
 };
 
+#ifndef BOOST_NO_VARIADIC_TEMPLATES
+template <class... R>
+struct CombineReductors {
+    template <class T>
+    struct impl {
+        static_assert(is_cl_scalar<T>::value, "Only scalar reductors may be combined");
+        typedef typename cl_vector_of<T, cl_fit_vec_size<sizeof...(R)>::value>::type result_type;
+
+        static result_type initial() {
+            result_type r;
+            assign_initial<R...>(r.s);
+            return r;
+        }
+
+        struct device_in : UserFunction<device_in, result_type(result_type, T)> {
+            static std::string name() { return "CombinedReductor_in_" + type_name<T>(); }
+
+            static void define(backend::source_generator &src, const std::string &fname = name()) {
+                define_scalar_fun<R...>(src);
+
+                src.function<result_type>(fname).open("(")
+                    .template parameter<result_type>("a")
+                    .template parameter<T>("b")
+                    .close(")").open("{");
+                src.new_line() << "return (" << type_name<result_type>() << ")( ";
+
+                int pos = 0;
+                partial_reduce<R...>(src, pos);
+
+                src << ");";
+                src.close("}");
+            }
+
+            template <class Head>
+            static void define_scalar_fun(backend::source_generator &src) {
+                Head::template impl<T>::device_in::define(src);
+            }
+
+            template <class Head, class... Tail>
+            static
+            typename std::enable_if<(sizeof...(Tail) > 0), void>::type
+            define_scalar_fun(backend::source_generator &src) {
+                Head::template impl<T>::device_in::define(src);
+                define_scalar_fun<Tail...>(src);
+            }
+
+            template <class Head>
+            static void partial_reduce(backend::source_generator &src, int &pos) {
+                src << Head::template impl<T>::device_in::name() << "(a.s" << pos << ", b) ";
+                pos++;
+            }
+
+            template <class Head, class... Tail>
+            static
+            typename std::enable_if<(sizeof...(Tail) > 0), void>::type
+            partial_reduce(backend::source_generator &src, int &pos) {
+                src << Head::template impl<T>::device_in::name() << "(a.s" << pos << ", b), ";
+                pos++;
+                partial_reduce<Tail...>(src, pos);
+            }
+        };
+
+        struct device_out : UserFunction<device_out, result_type(result_type, T)> {
+            static std::string name() { return "CombinedReductor_out" + type_name<T>(); }
+
+            static void define(backend::source_generator &src, const std::string &fname = name()) {
+                src.function<result_type>(fname).open("(")
+                    .template parameter<result_type>("a")
+                    .template parameter<result_type>("b")
+                    .close(")").open("{");
+                src.new_line() << "return (" << type_name<result_type>() << ")( ";
+
+                int pos = 0;
+                partial_reduce<R...>(src, pos);
+
+                src << ");";
+                src.close("}");
+            }
+
+            template <class Head>
+            static void partial_reduce(backend::source_generator &src, int &pos) {
+                src << Head::template impl<T>::device_in::name()
+                    << "(a.s" << pos << ", b.s" << pos << ") ";
+                pos++;
+            }
+
+            template <class Head, class... Tail>
+            static
+            typename std::enable_if<(sizeof...(Tail) > 0), void>::type
+            partial_reduce(backend::source_generator &src, int &pos) {
+                src << Head::template impl<T>::device_in::name()
+                    << "(a.s" << pos << ", b.s" << pos << "), ";
+                pos++;
+                partial_reduce<Tail...>(src, pos);
+            }
+        };
+
+        result_type operator()(result_type a, result_type b) const {
+            result_type r;
+            partial_reduce<R...>(r.s, a.s, b.s);
+            return r;
+        }
+
+        private:
+            template <class Head>
+            static void assign_initial(T *p) {
+                *p++ = Head::template impl<T>::initial();
+            }
+
+            template <class Head, class... Tail>
+            static
+            typename std::enable_if<(sizeof...(Tail) > 0), void>::type
+            assign_initial(T *p) {
+                *p++ = Head::template impl<T>::initial();
+                assign_initial<Tail...>(p);
+            }
+
+            template <class Head>
+            void partial_reduce(T *ptr, const T *a, const T *b) const {
+                *ptr++ = typename Head::template impl<T>()(*a++, *b++);
+            }
+
+            template <class Head, class... Tail>
+            typename std::enable_if<(sizeof...(Tail) > 0), void>::type
+            partial_reduce(T *ptr, const T *a, const T *b) const {
+                *ptr++ = typename Head::template impl<T>()(*a++, *b++);
+                partial_reduce<Tail...>(ptr, a, b);
+            }
+    };
+};
+
+typedef CombineReductors<MIN, MAX> MIN_MAX;
+#endif
+
 /// Parallel reduction of arbitrary expression.
 /**
  * Reduction uses small temporary buffer on each device present in the queue
  * parameter. One Reductor class for each reduction kind is enough per thread
  * of execution.
  */
-template <typename real, class RDC = SUM>
+template <typename ScalarType, class RDC = SUM>
 class Reductor {
     public:
+        typedef typename RDC::template impl<ScalarType>::result_type result_type;
+
         /// Constructor.
         Reductor(const std::vector<backend::command_queue> &queue
 #ifndef VEXCL_NO_STATIC_CONTEXT_CONSTRUCTORS
                 = current_context().queue()
 #endif
-                );
+                ) : queue(queue) {}
 
         /// Compute reduction of a vector expression.
         template <class Expr>
 #ifdef DOXYGEN
-        real
+        result_type
 #else
         typename std::enable_if<
             boost::proto::matches<Expr, vector_expr_grammar>::value,
-            real
+            result_type
         >::type
 #endif
-        operator()(const Expr &expr) const;
+        operator()(const Expr &expr) const {
+            using namespace detail;
+
+            static kernel_cache cache;
+
+            auto &data_cache = get_data_cache();
+
+            get_expression_properties prop;
+            extract_terminals()(expr, prop);
+
+            result_type initial = RDC::template impl<ScalarType>::initial();
+
+            // If expression is of zero size, then there is nothing to do. Hurray!
+            if (prop.size == 0) return initial;
+
+            // Sometimes the expression only knows its size:
+            if (prop.size && prop.part.empty())
+                prop.part = vex::partition(prop.size, queue);
+
+            for(unsigned d = 0; d < queue.size(); ++d) {
+                auto kernel = cache.find(queue[d]);
+
+                backend::select_context(queue[d]);
+
+                if (kernel == cache.end()) {
+                    backend::source_generator source(queue[d]);
+
+                    output_terminal_preamble termpream(source, queue[d], "prm", empty_state());
+                    boost::proto::eval(boost::proto::as_child(expr),  termpream);
+
+                    typedef typename RDC::template impl<ScalarType>::device_in  fun_in;
+                    typedef typename RDC::template impl<ScalarType>::device_out fun_out;
+                    boost::proto::eval(boost::proto::as_child( fun_in()( result_type(), ScalarType()) ), termpream);
+                    boost::proto::eval(boost::proto::as_child( fun_out()( result_type(), result_type()) ), termpream);
+
+                    source.kernel("vexcl_reductor_kernel")
+                        .open("(").template parameter<size_t>("n");
+
+                    extract_terminals()( expr, declare_expression_parameter(source, queue[d], "prm", empty_state()) );
+
+                    source.template parameter< global_ptr<result_type> >("g_odata");
+
+                    if (!backend::is_cpu(queue[d]))
+                        source.template smem_parameter<result_type>();
+
+                    source.close(")");
+
+
+                    source.open("{");
+
+                    local_sum<Expr, RDC>::get(queue[d], expr, source);
+
+                    if ( backend::is_cpu(queue[d]) ) {
+                        source.new_line() << "g_odata[" << source.group_id(0) << "] = mySum;";
+                        source.close("}");
+
+                        kernel = cache.insert(queue[d], backend::kernel(
+                                    queue[d], source.str(), "vexcl_reductor_kernel"));
+                    } else {
+                        source.smem_declaration<ScalarType>();
+                        source.new_line() << type_name< shared_ptr<result_type> >() << " sdata = smem;";
+
+                        source.new_line() << "size_t tid = " << source.local_id(0) << ";";
+                        source.new_line() << "size_t block_size = " << source.local_size(0) << ";";
+
+                        source.new_line() << "sdata[tid] = mySum;";
+                        source.new_line().barrier();
+                        for(unsigned bs = 512; bs > 0; bs /= 2) {
+                            source.new_line() << "if (block_size >= " << bs * 2 << ")";
+                            source.open("{").new_line() << "if (tid < " << bs << ") "
+                                "{ sdata[tid] = mySum = " << fun_out::name() << "(mySum, sdata[tid + " << bs << "]); }";
+                            source.new_line().barrier().close("}");
+                        }
+                        source.new_line() << "if (tid == 0) g_odata[" << source.group_id(0) << "] = sdata[0];";
+                        source.close("}");
+
+                        kernel = cache.insert(queue[d], backend::kernel(
+                                    queue[d], source.str(), "vexcl_reductor_kernel",
+                                    sizeof(ScalarType)));
+                    }
+                }
+
+                if (size_t psize = prop.part_size(d)) {
+                    auto data = data_cache.find(queue[d]);
+                    if (data == data_cache.end())
+                        data = data_cache.insert(queue[d], reductor_data(queue[d]));
+
+                    kernel->second.push_arg(psize);
+
+                    extract_terminals()(
+                            expr,
+                            set_expression_argument(kernel->second, d, prop.part_start(d), empty_state())
+                            );
+
+                    kernel->second.push_arg(data->second.dbuf);
+
+                    if (!backend::is_cpu(queue[d]))
+                        kernel->second.set_smem(
+                                [](size_t wgs){
+                                return wgs * sizeof(result_type);
+                                });
+
+                    kernel->second(queue[d]);
+                }
+            }
+
+            for(unsigned d = 0; d < queue.size(); d++) {
+                if (prop.part_size(d)) {
+                    auto data = data_cache.find(queue[d]);
+
+                    data->second.dbuf.read(queue[d], 0, data->second.hbuf.size(), data->second.hbuf.data());
+                }
+            }
+
+            result_type result = initial;
+            typename RDC::template impl<ScalarType> rdc;
+            for(unsigned d = 0; d < queue.size(); d++) {
+                if (prop.part_size(d)) {
+                    auto data = data_cache.find(queue[d]);
+
+                    queue[d].finish();
+
+                    result = rdc(result, std::accumulate(
+                                data->second.hbuf.begin(), data->second.hbuf.end(),
+                                initial, rdc));
+                }
+            }
+
+            return result;
+        }
 
         /// Compute reduction of a multivector expression.
         template <class Expr>
 #ifdef DOXYGEN
-        std::array<real, N>
+        std::array<result_type, N>
 #else
         typename std::enable_if<
             boost::proto::matches<Expr, multivector_expr_grammar>::value &&
             !boost::proto::matches<Expr, vector_expr_grammar>::value,
-            std::array<real, std::result_of<traits::multiex_dimension(Expr)>::type::value>
+            std::array<result_type, std::result_of<traits::multiex_dimension(Expr)>::type::value>
         >::type
 #endif
-        operator()(const Expr &expr) const;
+        operator()(const Expr &expr) const {
+            const size_t dim = std::result_of<traits::multiex_dimension(Expr)>::type::value;
+            std::array<result_type, dim> result;
+
+            assign_subexpressions<0, dim, Expr>(result, expr);
+
+            return result;
+        }
     private:
         mutable std::vector<backend::command_queue> queue;
 
         struct reductor_data {
-            std::vector<real>            hbuf;
-            backend::device_vector<real> dbuf;
+            std::vector<result_type>            hbuf;
+            backend::device_vector<result_type> dbuf;
 
             reductor_data(const backend::command_queue &q)
                 : hbuf(backend::kernel::num_workgroups(q)),
@@ -189,12 +473,12 @@ class Reductor {
 
         template <size_t I, size_t N, class Expr>
         typename std::enable_if<I == N, void>::type
-        assign_subexpressions(std::array<real, N> &, const Expr &) const
+        assign_subexpressions(std::array<result_type, N> &, const Expr &) const
         { }
 
         template <size_t I, size_t N, class Expr>
-        typename std::enable_if<I < N, void>::type
-        assign_subexpressions(std::array<real, N> &result, const Expr &expr) const
+        typename std::enable_if<(I < N), void>::type
+        assign_subexpressions(std::array<result_type, N> &result, const Expr &expr) const
         {
             result[I] = (*this)(detail::extract_subexpression<I>()(expr));
 
@@ -208,12 +492,12 @@ class Reductor {
             {
                 using namespace detail;
 
-                typedef typename OP::template impl<real>::device fun;
-                real initial = OP::template impl<real>::initial();
+                typedef typename OP::template impl<ScalarType>::device_in fun;
+                result_type initial = OP::template impl<ScalarType>::initial();
 
                 source.new_line()
-                    << type_name<real>() << " mySum = ("
-                    << type_name<real>() << ")" << initial << ";";
+                    << type_name<result_type>() << " mySum = ("
+                    << type_name<result_type>() << ")" << initial << ";";
                 source.grid_stride_loop().open("{");
 
                 output_local_preamble loc_init(source, q, "prm", empty_state());
@@ -236,20 +520,20 @@ class Reductor {
                 using namespace detail;
 
                 source.new_line()
-                    << type_name<real>() << " mySum = ("
-                    << type_name<real>() << ")0, c = ("
-                    << type_name<real>() << ")0;";
+                    << type_name<result_type>() << " mySum = ("
+                    << type_name<result_type>() << ")0, c = ("
+                    << type_name<result_type>() << ")0;";
                 source.grid_stride_loop().open("{");
 
                 output_local_preamble loc_init(source, q, "prm", empty_state());
                 boost::proto::eval(expr, loc_init);
 
-                source.new_line() << type_name<real>() << " y = (";
+                source.new_line() << type_name<result_type>() << " y = (";
                 vector_expr_context expr_ctx(source, q, "prm", empty_state());
                 boost::proto::eval(expr, expr_ctx);
                 source << ") - c;";
 
-                source.new_line() << type_name<real>() << " t = mySum + y;";
+                source.new_line() << type_name<result_type>() << " t = mySum + y;";
                 source.new_line() << "c = (t - mySum) - y;";
                 source.new_line() << "mySum = t;";
 
@@ -257,162 +541,6 @@ class Reductor {
             }
         };
 };
-
-#ifndef DOXYGEN
-template <typename real, class RDC>
-Reductor<real,RDC>::Reductor(const std::vector<backend::command_queue> &queue)
-    : queue(queue)
-{ }
-
-template <typename real, class RDC> template <class Expr>
-typename std::enable_if<
-    boost::proto::matches<Expr, vector_expr_grammar>::value,
-    real
->::type
-Reductor<real,RDC>::operator()(const Expr &expr) const {
-    using namespace detail;
-
-    static kernel_cache cache;
-
-    auto &data_cache = get_data_cache();
-
-    get_expression_properties prop;
-    extract_terminals()(expr, prop);
-
-    real initial = RDC::template impl<real>::initial();
-
-    // If expression is of zero size, then there is nothing to do. Hurray!
-    if (prop.size == 0) return initial;
-
-    // Sometimes the expression only knows its size:
-    if (prop.size && prop.part.empty())
-        prop.part = vex::partition(prop.size, queue);
-
-    for(unsigned d = 0; d < queue.size(); ++d) {
-        auto kernel = cache.find(queue[d]);
-
-        backend::select_context(queue[d]);
-
-        if (kernel == cache.end()) {
-            backend::source_generator source(queue[d]);
-
-            output_terminal_preamble termpream(source, queue[d], "prm", empty_state());
-            boost::proto::eval(boost::proto::as_child(expr),  termpream);
-
-            typedef typename RDC::template impl<real>::device fun;
-            boost::proto::eval(boost::proto::as_child( fun()( real(), real()) ), termpream);
-
-            source.kernel("vexcl_reductor_kernel")
-                .open("(").template parameter<size_t>("n");
-
-            extract_terminals()( expr, declare_expression_parameter(source, queue[d], "prm", empty_state()) );
-
-            source.template parameter< global_ptr<real> >("g_odata");
-
-            if (!backend::is_cpu(queue[d]))
-                source.template smem_parameter<real>();
-
-            source.close(")");
-
-
-            source.open("{");
-
-            local_sum<Expr, RDC>::get(queue[d], expr, source);
-
-            if ( backend::is_cpu(queue[d]) ) {
-                source.new_line() << "g_odata[" << source.group_id(0) << "] = mySum;";
-                source.close("}");
-
-                kernel = cache.insert(queue[d], backend::kernel(
-                            queue[d], source.str(), "vexcl_reductor_kernel"));
-            } else {
-                source.smem_declaration<real>();
-                source.new_line() << type_name< shared_ptr<real> >() << " sdata = smem;";
-
-                source.new_line() << "size_t tid = " << source.local_id(0) << ";";
-                source.new_line() << "size_t block_size = " << source.local_size(0) << ";";
-
-                source.new_line() << "sdata[tid] = mySum;";
-                source.new_line().barrier();
-                for(unsigned bs = 512; bs > 0; bs /= 2) {
-                    source.new_line() << "if (block_size >= " << bs * 2 << ")";
-                    source.open("{").new_line() << "if (tid < " << bs << ") "
-                        "{ sdata[tid] = mySum = " << fun::name() << "(mySum, sdata[tid + " << bs << "]); }";
-                    source.new_line().barrier().close("}");
-                }
-                source.new_line() << "if (tid == 0) g_odata[" << source.group_id(0) << "] = sdata[0];";
-                source.close("}");
-
-                kernel = cache.insert(queue[d], backend::kernel(
-                            queue[d], source.str(), "vexcl_reductor_kernel",
-                            sizeof(real)));
-            }
-        }
-
-        if (size_t psize = prop.part_size(d)) {
-            auto data = data_cache.find(queue[d]);
-            if (data == data_cache.end())
-                data = data_cache.insert(queue[d], reductor_data(queue[d]));
-
-            kernel->second.push_arg(psize);
-
-            extract_terminals()(
-                    expr,
-                    set_expression_argument(kernel->second, d, prop.part_start(d), empty_state())
-                    );
-
-            kernel->second.push_arg(data->second.dbuf);
-
-            if (!backend::is_cpu(queue[d]))
-                kernel->second.set_smem(
-                        [](size_t wgs){
-                            return wgs * sizeof(real);
-                        });
-
-            kernel->second(queue[d]);
-        }
-    }
-
-    for(unsigned d = 0; d < queue.size(); d++) {
-        if (prop.part_size(d)) {
-            auto data = data_cache.find(queue[d]);
-
-            data->second.dbuf.read(queue[d], 0, data->second.hbuf.size(), data->second.hbuf.data());
-        }
-    }
-
-    real result = initial;
-    typename RDC::template impl<real> rdc;
-    for(unsigned d = 0; d < queue.size(); d++) {
-        if (prop.part_size(d)) {
-            auto data = data_cache.find(queue[d]);
-
-            queue[d].finish();
-
-            result = rdc(result, std::accumulate(
-                        data->second.hbuf.begin(), data->second.hbuf.end(),
-                        initial, rdc));
-        }
-    }
-
-    return result;
-}
-
-template <typename real, class RDC> template <class Expr>
-typename std::enable_if<
-    boost::proto::matches<Expr, multivector_expr_grammar>::value &&
-    !boost::proto::matches<Expr, vector_expr_grammar>::value,
-    std::array<real, std::result_of<traits::multiex_dimension(Expr)>::type::value>
->::type
-Reductor<real,RDC>::operator()(const Expr &expr) const {
-    const size_t dim = std::result_of<traits::multiex_dimension(Expr)>::type::value;
-    std::array<real, dim> result;
-
-    assign_subexpressions<0, dim, Expr>(result, expr);
-
-    return result;
-}
-#endif
 
 /// Returns an instance of vex::Reductor<T,R>
 /**

--- a/vexcl/types.hpp
+++ b/vexcl/types.hpp
@@ -317,6 +317,30 @@ struct is_cl_vector<T,
     > : std::true_type
 {};
 
+template <unsigned I, class Enable = void>
+struct cl_fit_vec_size { };
+
+template <> struct cl_fit_vec_size<1> : std::integral_constant<int, 1> {};
+template <> struct cl_fit_vec_size<2> : std::integral_constant<int, 2> {};
+
+template <unsigned I>
+struct cl_fit_vec_size<I, typename std::enable_if<(I>2) && (I<=4)>::type>
+: std::integral_constant<unsigned, 4> {};
+
+template <unsigned I>
+struct cl_fit_vec_size<I, typename std::enable_if<(I>4) && (I<=8)>::type>
+: std::integral_constant<unsigned, 8> {};
+
+template <unsigned I>
+struct cl_fit_vec_size<I, typename std::enable_if<(I>8) && (I<=16)>::type>
+: std::integral_constant<unsigned, 16> {};
+
+template <unsigned I>
+struct cl_fit_vec_size<I, typename std::enable_if<(I<1) || (I>16)>::type>
+{
+    static_assert(I >= 1 && I <= 16, "Unsupported vector size");
+};
+
 }
 
 /// \endcond

--- a/vexcl/vector_view.hpp
+++ b/vexcl/vector_view.hpp
@@ -782,9 +782,10 @@ struct terminal_preamble< reduced_vector_view<Expr, NDIM, NR, RDC> > {
         boost::proto::eval(boost::proto::as_child(term.expr), termpream);
 
         typedef typename detail::return_type<Expr>::type T;
-        typedef typename RDC::template impl<T>::device fun;
+        typedef typename RDC::template impl<T>::result_type T_out;
+        typedef typename RDC::template impl<T>::device_in fun_in;
 
-        boost::proto::eval(boost::proto::as_child( fun() (T(), T()) ), termpream);
+        boost::proto::eval(boost::proto::as_child( fun_in() (T_out(), T()) ), termpream);
     }
 };
 
@@ -796,10 +797,11 @@ struct local_terminal_init< reduced_vector_view<Expr, NDIM, NR, RDC> > {
             detail::kernel_generator_state_ptr state)
     {
         typedef typename detail::return_type<Expr>::type T;
-        typedef typename RDC::template impl<T>::device fun;
+        typedef typename RDC::template impl<T>::result_type T_out;
+        typedef typename RDC::template impl<T>::device_in fun;
 
-        src.new_line() << type_name<T>() << " " << prm_name << "_sum = (" <<
-            type_name<T>() << ")" << RDC::template impl<T>::initial() << ";";
+        src.new_line() << type_name<T_out>() << " " << prm_name << "_sum = (" <<
+            type_name<T_out>() << ")" << RDC::template impl<T>::initial() << ";";
         src.open("{");
 
         src.new_line()


### PR DESCRIPTION
Example:
```cpp
Reductor<int, CombineReductors<MIN, MAX> > minmax(ctx);
cl_int2 mm = minmax(x);
```

The min max example seems to be common enough to warrant a typedef (also introduced in this PR):
```cpp
typedef CombineReductors<MIN, MAX> MIN_MAX;
```

See #192