### PR TITLE
Allow passing generated kernel args for each GPU

### DIFF
--- a/vexcl/generator.hpp
+++ b/vexcl/generator.hpp
@@ -560,6 +560,13 @@ class kernel {
             }
         }
 
+        template <class T>
+        void push_arg(const std::vector<T> &args) {
+            for(unsigned d = 0; d < queue.size(); d++) {
+                cache.find(backend::get_context_id(queue[d]))->second.push_arg(args[d]);
+            }
+        }
+
         void operator()() {
             for(unsigned d = 0; d < queue.size(); d++) {
                 auto &K = cache.find(backend::get_context_id(queue[d]))->second;


### PR DESCRIPTION
Kernel args packed into `std::vector` will be unpacked and passed
to the generated kernels on respective devices.

See #202