### PR TITLE
Make VEX_CONSTANTS castable to their originating values

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ add_vexcl_test(events                   events.cpp)
 add_vexcl_test(image                    image.cpp)
 add_vexcl_test(custom_kernel            custom_kernel.cpp)
 add_vexcl_test(eval                     eval.cpp)
+add_vexcl_test(constants                constants.cpp)
 add_vexcl_test(multiple_objects         "dummy1.cpp;dummy2.cpp")
 
 if (NOT DEFINED ENV{APPVEYOR})

--- a/tests/constants.cpp
+++ b/tests/constants.cpp
@@ -1,0 +1,22 @@
+#define BOOST_TEST_MODULE Constants
+#include <boost/test/unit_test.hpp>
+#include <vexcl/vector.hpp>
+#include <vexcl/constants.hpp>
+#include "context_setup.hpp"
+
+BOOST_AUTO_TEST_CASE(constants) {
+    const size_t N = 1024;
+
+    vex::vector<int> x(ctx, N);
+
+    VEX_CONSTANT(forty_two, 42);
+
+    x = forty_two();
+
+    BOOST_CHECK_EQUAL(forty_two, 42);
+
+    check_sample(x, [=](size_t, int v) { BOOST_CHECK_EQUAL(v, forty_two); });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/vexcl/constants.hpp
+++ b/vexcl/constants.hpp
@@ -143,8 +143,9 @@ struct kernel_arg_setter< user_constant<Impl> >
   struct constant_##name {                                                     \
     typedef decltype(value) value_type;                                        \
     static std::string get() {                                                 \
+      static const value_type v = value;                                       \
       std::ostringstream s;                                                    \
-      s << "( " << std::scientific << std::setprecision(16) << value << " )";  \
+      s << "( " << std::scientific << std::setprecision(16) << v << " )";      \
       return s.str();                                                          \
     }                                                                          \
     decltype(boost::proto::as_expr<vex::vector_domain>(                        \
@@ -152,6 +153,10 @@ struct kernel_arg_setter< user_constant<Impl> >
     operator()() const {                                                       \
       return boost::proto::as_expr<vex::vector_domain>(                        \
           vex::user_constant<constant_##name>());                              \
+    }                                                                          \
+    operator value_type() const {                                              \
+      static const value_type v = value;                                       \
+      return v;                                                                \
     }                                                                          \
   };                                                                           \
   const constant_##name name = {}


### PR DESCRIPTION
So that a constant defined with `VEX_CONSTANT(name, expr)` could be used in host code with `name`. Constants are still useable in vector expressions as `name()`.