### PR TITLE
Fixing OpenCL download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     - . .travis/install_amd_sdk.sh;
     - . .travis/install_boost.sh;
     - cmake --version
-    - ls -lR /usr/local/clang-3.9.0
+    - env
 
 script:
     - mkdir -p build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,14 @@ before_install:
     - . .travis/install_amd_sdk.sh;
     - . .travis/install_boost.sh;
     - cmake --version
+    - ls -lR /usr/local/clang-3.9.0
 
 script:
     - mkdir -p build && cd build
     - cmake -DVEXCL_TEST_COVERAGE=ON -DVEXCL_BUILD_TESTS=ON -DVEXCL_BUILD_EXAMPLES=ON -DVEXCL_BACKEND=${VEXCL_BACKEND} ..
     - make -j2
     - export CPATH=${CPATH}:${BOOST_ROOT}
+    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/clang-3.9.0/lib
     - ./examples/devlist && ctest --output-on-failure
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 script:
     - mkdir -p build && cd build
     - cmake -DVEXCL_TEST_COVERAGE=ON -DVEXCL_BUILD_TESTS=ON -DVEXCL_BUILD_EXAMPLES=ON -DVEXCL_BACKEND=${VEXCL_BACKEND} ..
-    - make
+    - make -j2
     - export CPATH=${CPATH}:${BOOST_ROOT}
     - ./examples/devlist && ctest --output-on-failure
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ addons:
     packages:
       - opencl-headers
       - lcov
-      - python-pip
 cache:
     directories:
         - ${HOME}/${BOOST_BASENAME}/boost
@@ -36,7 +35,6 @@ cache:
         - ${AMDAPPSDKROOT}
 
 before_install:
-    - if [ "$VEXCL_BACKEND" = "JIT" ] && [ "$CC" = "clang" ] ; then pip install --user cmake ; fi
     - . .travis/install_amd_sdk.sh;
     - . .travis/install_boost.sh;
     - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     - cmake -DVEXCL_TEST_COVERAGE=ON -DVEXCL_BUILD_TESTS=ON -DVEXCL_BUILD_EXAMPLES=ON -DVEXCL_BACKEND=${VEXCL_BACKEND} ..
     - make -j2
     - export CPATH=${CPATH}:${BOOST_ROOT}
-    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(dirname $(which clang++))/../lib
+    - if [ "$VEXCL_BACKEND" = "JIT" ] && [ "$CC" = "clang" ] ; then export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(dirname $(which clang++))/../lib ; fi
     - ./examples/devlist && ctest --output-on-failure
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,13 @@ before_install:
     - . .travis/install_amd_sdk.sh;
     - . .travis/install_boost.sh;
     - cmake --version
-    - env
 
 script:
     - mkdir -p build && cd build
     - cmake -DVEXCL_TEST_COVERAGE=ON -DVEXCL_BUILD_TESTS=ON -DVEXCL_BUILD_EXAMPLES=ON -DVEXCL_BACKEND=${VEXCL_BACKEND} ..
     - make -j2
     - export CPATH=${CPATH}:${BOOST_ROOT}
-    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/clang-3.9.0/lib
+    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(dirname $(which clang++))/../lib
     - ./examples/devlist && ctest --output-on-failure
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     packages:
       - opencl-headers
       - lcov
-
+      - python-pip
 cache:
     directories:
         - ${HOME}/${BOOST_BASENAME}/boost
@@ -36,14 +36,18 @@ cache:
         - ${AMDAPPSDKROOT}
 
 before_install:
+    - if [ "$VEXCL_BACKEND" = "JIT" ] && [ "$CC" = "clang" ] ; then pip install --user cmake ; fi
     - . .travis/install_amd_sdk.sh;
     - . .travis/install_boost.sh;
+    - cmake --version
+
 script:
     - mkdir -p build && cd build
     - cmake -DVEXCL_TEST_COVERAGE=ON -DVEXCL_BUILD_TESTS=ON -DVEXCL_BUILD_EXAMPLES=ON -DVEXCL_BACKEND=${VEXCL_BACKEND} ..
     - make -j2
     - export CPATH=${CPATH}:${BOOST_ROOT}
     - ./examples/devlist && ctest --output-on-failure
+
 after_success:
     - lcov --directory tests --base-directory ../vexcl --capture --output-file coverage.info
     - lcov --remove coverage.info '/usr*' '*/cl.hpp' -o coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 language: cpp
 compiler:
     - gcc

--- a/.travis/install_amd_sdk.sh
+++ b/.travis/install_amd_sdk.sh
@@ -8,7 +8,7 @@ export CMAKE_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64
 
 if [ ! -e ${AMDAPPSDKROOT}/bin/x86_64/clinfo ]; then
     # Location from which get nonce and file name from
-    URL="http://developer.amd.com/tools-and-sdks/opencl-zone/opencl-tools-sdks/amd-accelerated-parallel-processing-app-sdk/"
+    URL="http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/"
     URLDOWN="http://developer.amd.com/amd-license-agreement-appsdk/"
 
     NONCE1_STRING='name="amd_developer_central_downloads_page_nonce"'
@@ -16,7 +16,8 @@ if [ ! -e ${AMDAPPSDKROOT}/bin/x86_64/clinfo ]; then
     POSTID_STRING='name="post_id"'
     NONCE2_STRING='name="amd_developer_central_nonce"'
 
-    #For newest FORM=`wget -qO - $URL | sed -n '/download-2/,/64-bit/p'`
+    # This gets the second latest (2.9.1 ATM, latest is 3.0)
+    # For newest: FORM=`wget -qO - $URL | sed -n '/download-2/,/64-bit/p'`
     FORM=`wget -qO - $URL | sed -n '/download-5/,/64-bit/p'`
 
     # Get nonce from form

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,15 +137,20 @@ if (NOT "${Boost_VERSION}" STRLESS "106100")
     add_library(JIT INTERFACE)
     add_library(VexCL::JIT ALIAS JIT)
 
-    target_link_libraries(JIT INTERFACE
-        Common
-        $<$<CXX_COMPILER_ID:GNU>:${OpenMP_CXX_FLAGS} dl>
-        $<$<CXX_COMPILER_ID:Clang>:${OpenMP_CXX_FLAGS} dl>
-        $<$<CXX_COMPILER_ID:Intel>:${OpenMP_CXX_FLAGS} dl>
-        )
+    # CMake 3.9, allows correct linking with clang
+    if(TARGET OpenMP::OpenMP_CXX)
+        target_link_libraries(JIT INTERFACE OpenMP::OpenMP_CXX Common)
+    else()
+        target_link_libraries(JIT INTERFACE
+            Common
+            $<$<CXX_COMPILER_ID:GNU>:${OpenMP_CXX_FLAGS} dl>
+            $<$<CXX_COMPILER_ID:Clang>:${OpenMP_CXX_FLAGS} dl>
+            $<$<CXX_COMPILER_ID:Intel>:${OpenMP_CXX_FLAGS} dl>
+            )
+        target_compile_options(JIT INTERFACE ${OpenMP_CXX_FLAGS})
+    endif()
 
     target_compile_definitions(JIT INTERFACE VEXCL_BACKEND_JIT)
-    target_compile_options(JIT INTERFACE ${OpenMP_CXX_FLAGS})
 
     message(STATUS "Found VexCL::JIT")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,20 +137,24 @@ if (NOT "${Boost_VERSION}" STRLESS "106100")
     add_library(JIT INTERFACE)
     add_library(VexCL::JIT ALIAS JIT)
 
-    # CMake 3.9, allows correct linking with clang
+    # CMake 3.9, allows correct linking with Clang
     if(TARGET OpenMP::OpenMP_CXX)
         target_link_libraries(JIT INTERFACE OpenMP::OpenMP_CXX Common)
     else()
+        if(CXX_COMPILER_ID STREQUAL Clang)
+            message(WARNING "Clang JIT needs CMake 3.9 to properly detect OpenMP linker flags!")
+        endif()
+        # Clang may need -fopenmp=libiomp5 instead, can't be detected here without CMake 3.9
         target_link_libraries(JIT INTERFACE
-            Common
-            $<$<CXX_COMPILER_ID:GNU>:${OpenMP_CXX_FLAGS} dl>
-            $<$<CXX_COMPILER_ID:Clang>:${OpenMP_CXX_FLAGS} dl>
-            $<$<CXX_COMPILER_ID:Intel>:${OpenMP_CXX_FLAGS} dl>
+            $<$<CXX_COMPILER_ID:GNU>:${OpenMP_CXX_FLAGS}>
+            $<$<CXX_COMPILER_ID:Clang>:-fopenmp=libomp>
+            $<$<CXX_COMPILER_ID:Intel>:${OpenMP_CXX_FLAGS}>
             )
         target_compile_options(JIT INTERFACE ${OpenMP_CXX_FLAGS})
     endif()
 
     target_compile_definitions(JIT INTERFACE VEXCL_BACKEND_JIT)
+    target_link_libraries(JIT INTERFACE Common ${CMAKE_DL_LIBS})
 
     message(STATUS "Found VexCL::JIT")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,24 +137,21 @@ if (NOT "${Boost_VERSION}" STRLESS "106100")
     add_library(JIT INTERFACE)
     add_library(VexCL::JIT ALIAS JIT)
 
-    # CMake 3.9, allows correct linking with Clang
+    # CMake 3.9 FindOpenMP allows correct linking with Clang in more cases
     if(TARGET OpenMP::OpenMP_CXX)
         target_link_libraries(JIT INTERFACE OpenMP::OpenMP_CXX Common)
     else()
-        if(CXX_COMPILER_ID STREQUAL Clang)
-            message(WARNING "Clang JIT needs CMake 3.9 to properly detect OpenMP linker flags!")
-        endif()
         # Clang may need -fopenmp=libiomp5 instead, can't be detected here without CMake 3.9
         target_link_libraries(JIT INTERFACE
             $<$<CXX_COMPILER_ID:GNU>:${OpenMP_CXX_FLAGS}>
-            $<$<CXX_COMPILER_ID:Clang>:-fopenmp=libomp>
+            $<$<CXX_COMPILER_ID:Clang>:${OpenMP_CXX_FLAGS}>
             $<$<CXX_COMPILER_ID:Intel>:${OpenMP_CXX_FLAGS}>
             )
         target_compile_options(JIT INTERFACE ${OpenMP_CXX_FLAGS})
     endif()
 
-    target_compile_definitions(JIT INTERFACE VEXCL_BACKEND_JIT)
     target_link_libraries(JIT INTERFACE Common ${CMAKE_DL_LIBS})
+    target_compile_definitions(JIT INTERFACE VEXCL_BACKEND_JIT)
 
     message(STATUS "Found VexCL::JIT")
 endif()


### PR DESCRIPTION
Fixing the OpenCL build on Travis. The URL changed, breaking the download script. This also adds `-j2` to the build procedure and removes sudo, which should speed up the build a bit.