### PR TITLE
Switch to Boost 1.66 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 env:
   global:
     - OMP_NUM_THREADS=4
-    - BOOST_BASENAME=boost_1_62_0
+    - BOOST_BASENAME=boost_1_66_0
     - AMDAPPSDKROOT=${HOME}/AMDAPPSDK
 
 matrix:
@@ -30,9 +30,6 @@ matrix:
   - os: osx
     osx_image: xcode9.1
     env: VEXCL_BACKEND=JIT
-  allow_failures:
-  - os: osx
-    env: VEXCL_BACKEND=Compute
 
 addons:
   apt:
@@ -48,7 +45,7 @@ cache:
 
 before_install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then source .travis/install_amd_sdk.sh ; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then source .travis/install_boost.sh ; fi
+    - source .travis/install_boost.sh 2>&1 > /dev/null
     - cmake --version
 
 script:

--- a/.travis/install_boost.sh
+++ b/.travis/install_boost.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
 export BOOST_ROOT=${HOME}/${BOOST_BASENAME}
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${BOOST_ROOT}/stage/lib
+fi
 
 if [ ! -e ${BOOST_ROOT}/boost/config.hpp ]; then
     pushd ${HOME}
-    wget https://downloads.sourceforge.net/project/boost/boost/1.62.0/${BOOST_BASENAME}.tar.bz2
+    wget https://downloads.sourceforge.net/project/boost/boost/1.66.0/${BOOST_BASENAME}.tar.bz2
     rm -rf $BOOST_BASENAME
     tar xf ${BOOST_BASENAME}.tar.bz2
-    (cd $BOOST_BASENAME && ./bootstrap.sh && ./b2)
+    (cd ${BOOST_BASENAME} && ./bootstrap.sh --with-libraries=chrono,date_time,filesystem,program_options,system,thread,test && ./b2)
     popd
 fi
 


### PR DESCRIPTION
* enable boost compilation on OSX,
* suppress output from boost compilation,
* build only what's necessary in boost,
* remove OSX/compute from allowed failures

Closes #227