### PR TITLE
Fix/opencl include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ option(VEXCL_SHOW_COPIES "Log vector copies to stdout for debugging purposes" OF
 set(VEXCL_CHECK_SIZES 0 CACHE STRING "Check that expressions have correct sizes")
 
 #----------------------------------------------------------------------------
+# Installation options
+#----------------------------------------------------------------------------
+option(VEXCL_INSTALL_CL_HPP "Install the OpenCL C++ header provided by VexCL" OFF)
+
+#----------------------------------------------------------------------------
 # Find Boost
 #----------------------------------------------------------------------------
 option(Boost_USE_STATIC_LIBS "Use static versions of Boost libraries" OFF)
@@ -233,7 +238,9 @@ if (VEXCL_MASTER_PROJECT)
     install(TARGETS Common EXPORT VexCLTargets)
 
     if (TARGET VexCL::OpenCL)
-        install(DIRECTORY CL DESTINATION include)
+        if(VEXCL_INSTALL_CL_HPP)
+            install(DIRECTORY CL DESTINATION include)
+        endif()
         install(TARGETS OpenCL EXPORT VexCLTargets)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ if (VEXCL_MASTER_PROJECT)
     install(TARGETS Common EXPORT VexCLTargets)
 
     if (TARGET VexCL::OpenCL)
+        install(DIRECTORY CL DESTINATION include)
         install(TARGETS OpenCL EXPORT VexCLTargets)
     endif()
 

--- a/vexcl/backend/opencl.hpp
+++ b/vexcl/backend/opencl.hpp
@@ -36,11 +36,7 @@ THE SOFTWARE.
 #endif
 
 #include <vexcl/backend/opencl/defines.hpp>
-#if defined(__APPLE__) || defined(__MACOSX)
-#include <OpenCL/cl.h>
-#else
-#include <CL/cl.h>
-#endif
+#include <CL/cl.hpp>
 
 #include <vexcl/backend/opencl/error.hpp>
 #include <vexcl/backend/opencl/context.hpp>

--- a/vexcl/backend/opencl.hpp
+++ b/vexcl/backend/opencl.hpp
@@ -36,7 +36,11 @@ THE SOFTWARE.
 #endif
 
 #include <vexcl/backend/opencl/defines.hpp>
-#include <CL/cl.hpp>
+#if defined(__APPLE__) || defined(__MACOSX)
+#include <OpenCL/cl.h>
+#else
+#include <CL/cl.h>
+#endif
 
 #include <vexcl/backend/opencl/error.hpp>
 #include <vexcl/backend/opencl/context.hpp>


### PR DESCRIPTION
When trying to use VexCL in a separated project using the find_package(VexCL) line in the CMakeLists file, the compiler was not able to find the CL/cl.hpp file and therefore fails not being able to use the C++ OpenCL version.

This PR just modifies the install directive to copy such folder into the *include* folder