### PR TITLE
Fixing warnings with CMake, use latest tested features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.11)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_VERSION})
+endif()
+
+
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type selected, default to RelWithDebInfo")
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type")


### PR DESCRIPTION
This reduces warnings in CMake by selecting the newest policies up to the current version (3.11). No if statement is needed on the if statement because 3.12 will recognize the `3.1...3.11` syntax. For maintenance, when VexCL is tested on new CMake versions and is verified to work, only the upper bound will need to be changed.

This also removes "old visibility policy" setting warnings for users trying to use visibility.