### PR TITLE
Using CMake targets, fixes issues with pthread not being added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ find_package(Boost REQUIRED COMPONENTS
     unit_test_framework
     )
 
+# Ensure all targets are available
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/VexCLBoostTargets.cmake")
+
 #----------------------------------------------------------------------------
 # Generic target
 #----------------------------------------------------------------------------
@@ -67,22 +70,21 @@ target_compile_features(Common INTERFACE
 )
 
 target_include_directories(Common INTERFACE
-    ${Boost_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
     )
 
 
 target_link_libraries(Common INTERFACE
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
+    Boost::filesystem
+    Boost::system
+    Boost::thread
     )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     target_link_libraries(Common INTERFACE
-        ${Boost_CHRONO_LIBRARY}
-        ${Boost_DATE_TIME_LIBRARY}
+        Boost::chrono
+        Boost::date_time
         )
 endif()
 
@@ -265,12 +267,18 @@ if (VEXCL_MASTER_PROJECT)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/VexCLConfig.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLConfig.cmake"
-        COPYONLY
+        @ONLY
         )
 
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/VexCLTools.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLTools.cmake"
+        COPYONLY
+        )
+
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/VexCLBoostTargets.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLBoostTargets.cmake"
         COPYONLY
         )
 
@@ -293,7 +301,10 @@ if (VEXCL_MASTER_PROJECT)
         )
 
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLTools.cmake
-        DESTINATION share/vexcl/cmake
+        FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLTools.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/cmake/VexCLBoostTargets.cmake
+        DESTINATION
+          share/vexcl/cmake
         )
 endif()

--- a/cmake/VexCLBoostTargets.cmake
+++ b/cmake/VexCLBoostTargets.cmake
@@ -1,0 +1,46 @@
+
+# Support for CMake < 3.6 or so
+# Unlike the real targets in CMake 3.6+, this does not resolve all
+# dependencies based on Boost version. Use with care.
+# This also may be used when CMake < 3.11 (3.10?) and CMake is older than Boost
+
+if(NOT TARGET Boost::system)
+    add_library(Boost::system IMPORTED INTERFACE)
+    set_target_properties(Boost::system PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${Boost_SYSTEM_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+        )
+endif()
+
+if(NOT TARGET Boost::filesystem)
+    add_library(Boost::filesystem IMPORTED INTERFACE)
+    set_target_properties(Boost::filesystem PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${Boost_FILESYSTEM_LIBRARY};Boost::system"
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+        )
+endif()
+
+if(NOT TARGET Boost::thread)
+    find_package(Threads)
+    add_library(Boost::thread IMPORTED INTERFACE)
+    set_target_properties(Boost::thread PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${Boost_THREAD_LIBRARY};Threads::Threads"
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+        )
+endif()
+
+if(NOT TARGET Boost::date_time)
+    add_library(Boost::date_time IMPORTED INTERFACE)
+    set_target_properties(Boost::date_time PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${Boost_DATE_TIME_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+        )
+endif()
+
+if(NOT TARGET Boost::chrono)
+    add_library(Boost::chrono IMPORTED INTERFACE)
+    set_target_properties(Boost::chrono PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${Boost_CHRONO_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+        )
+endif()

--- a/cmake/VexCLConfig.cmake.in
+++ b/cmake/VexCLConfig.cmake.in
@@ -20,7 +20,26 @@
 #   VexCL::CUDA
 #   VexCL::JIT
 
-find_package(OpenMP)
+include(CMakeFindDependencyMacro)
+
+find_dependency(OpenMP)
+
+set(Boost_USE_STATIC_LIBS @Boost_USE_STATIC_LIBS@)
+if(NOT BOOST_ROOT)
+    set(BOOST_ROOT @BOOST_ROOT@)
+endif()
+
+find_dependency(Boost REQUIRED COMPONENTS
+    chrono
+    date_time
+    filesystem
+    program_options
+    system
+    thread
+    unit_test_framework
+    )
+
+include("${CMAKE_CURRENT_LIST_DIR}/VexCLBoostTargets.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/VexCLTargets.cmake")
 

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(hello)
+
+find_package(VexCL)
+
+add_executable(hello hello.cpp)
+target_link_libraries(hello VexCL::OpenCL)

--- a/examples/simple/hello.cpp
+++ b/examples/simple/hello.cpp
@@ -1,0 +1,6 @@
+#include <vexcl/vexcl.hpp>
+
+int main() {
+    vex::Context ctx(vex::Filter::All);
+    std::cout << ctx << std::endl;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,3 +153,18 @@ if (VEXCL_BACKEND MATCHES "CUDA" OR VEXCL_BACKEND MATCHES "All")
         target_link_libraries(cusparse_cuda PUBLIC ${CUDA_cusparse_LIBRARY})
     endif()
 endif()
+
+#----------------------------------------------------------------------------
+# Test cmake build
+#----------------------------------------------------------------------------
+add_test(
+    NAME simple_cmake_build
+    COMMAND "${CMAKE_CTEST_COMMAND}"
+            --build-and-test
+            "${VexCL_SOURCE_DIR}/examples/simple/"
+            "${CMAKE_CURRENT_BINARY_DIR}/simple/"
+            --build-generator "${CMAKE_GENERATOR}"
+            --build-options -DBOOST_ROOT="${BOOST_ROOT}"
+            --test-command "${CMAKE_CTEST_COMMAND}"
+    )
+


### PR DESCRIPTION
This moves to using the CMake `Boost::` targets if they are available, and making them if they are not. The problem it is fixing (`-pthread` no being added when it is required on some systems) *should* be fixed even in the case the `Boost::` targets are not available (old CMake or simi-old CMake combined with newer Boost).

(The threads test case does not build on CentOS 7 system without this patch)