### PR TITLE
Fix for FindBoost running before/after VexCL

### DIFF
--- a/cmake/VexCLConfig.cmake.in
+++ b/cmake/VexCLConfig.cmake.in
@@ -29,7 +29,7 @@ if(NOT BOOST_ROOT)
     set(BOOST_ROOT @BOOST_ROOT@)
 endif()
 
-find_dependency(Boost REQUIRED COMPONENTS
+find_package(Boost REQUIRED COMPONENTS
     chrono
     date_time
     filesystem


### PR DESCRIPTION
Find dependency is too gentle; FindBoost was designed to be fully rerun. This fixes the issue in #245 .