### PR TITLE
Workaround for AMD SI GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(VEXCL_SHOW_KERNELS "Show generated kernels in tests and examples" OFF)
 option(VEXCL_CACHE_KERNELS "Cache compiled kernels offline" ON)
 option(VEXCL_SHOW_COPIES "Log vector copies to stdout for debugging purposes" OFF)
+option(VEXCL_AMD_SI_WORKAROUND "Implement workaround for AMD SI GPUs" OFF)
 set(VEXCL_CHECK_SIZES 0 CACHE STRING "Check that expressions have correct sizes")
 
 #----------------------------------------------------------------------------
@@ -67,6 +68,10 @@ target_compile_features(Common INTERFACE
     cxx_variadic_templates
     cxx_decltype
 )
+
+if (VEXCL_AMD_SI_WORKAROUND)
+    target_compile_definitions(Common INTERFACE VEXCL_AMD_SI_WORKAROUND)
+endif()
 
 target_include_directories(Common INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/vexcl/backend/opencl/source.hpp
+++ b/vexcl/backend/opencl/source.hpp
@@ -139,7 +139,12 @@ inline std::string standard_kernel_header(const command_queue &q) {
         "#elif defined(cl_amd_fp64)\n"
         "#  pragma OPENCL EXTENSION cl_amd_fp64: enable\n"
         "#endif\n"
-        ) + get_program_header(q);
+        )
+        + get_program_header(q)
+#ifdef VEXCL_AMD_SI_WORKAROUND
+        + "kernel void __null_kernel() {}\n"
+#endif
+        ;
 }
 
 /// Helper class for OpenCL source code generation.


### PR DESCRIPTION
Closes #254 

The workaround (described in #254) may be enabled by either turning the `VEXCL_AMD_SI_WORKAROUND` cmake option ON, or defining `VEXCL_AMD_SI_WORKAROUND` preprocessor macro directly.

When enabled, and if the device name is 'Hainan', it launches a dummy kernel after the main one.