### PR TITLE
CMake 312

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,12 +200,11 @@ if(TARGET JIT)
 
         set(VEXCL_OMP_FLAGS "${OpenMP_CXX_FLAGS}")
         foreach(item ${OpenMP_CXX_LIBRARIES})
-            set(VEXCL_OMP_FLAGS "${VEXCL_OMP_FLAGS} -l${item}")
+            set(VEXCL_OMP_FLAGS "${VEXCL_OMP_FLAGS} ${item}")
         endforeach()
-	message(STATUS "VEXCL_OMP_FLAGS=${VEXCL_OMP_FLAGS}")
 
         # Pass the required flags to code
-        target_compile_definitions(JIT INTERFACE VEXCL_OMP_FLAGS="${VEXCL_OMP_FLAGS}")
+        target_compile_definitions(JIT INTERFACE VEXCL_OMP_FLAGS=${VEXCL_OMP_FLAGS})
     endif()
 
     target_link_libraries(JIT INTERFACE Common ${CMAKE_DL_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 3.1...3.11)
+cmake_minimum_required(VERSION 3.1)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
-    cmake_policy(VERSION ${CMAKE_VERSION})
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+else()
+    cmake_policy(VERSION 3.12)
 endif()
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,9 +199,13 @@ if(TARGET JIT)
         endif()
 
         set(VEXCL_OMP_FLAGS "${OpenMP_CXX_FLAGS}")
-        foreach(item ${OpenMP_CXX_LIBRARIES})
-            set(VEXCL_OMP_FLAGS "${VEXCL_OMP_FLAGS} ${item}")
-        endforeach()
+
+        # We only need to add libraries to link to if this is using a preprocessor only OpenMP flag
+        if("${OpenMP_CXX_FLAGS}" MATCHES ".*X(clang|preprocessor).*")
+            foreach(item ${OpenMP_CXX_LIBRARIES})
+                set(VEXCL_OMP_FLAGS "${VEXCL_OMP_FLAGS} ${item}")
+            endforeach()
+        endif()
 
         # Pass the required flags to code
         target_compile_definitions(JIT INTERFACE VEXCL_OMP_FLAGS=${VEXCL_OMP_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,15 @@ if(TARGET JIT)
                 )
             target_compile_options(JIT INTERFACE ${OpenMP_CXX_FLAGS})
         endif()
+
+        set(VEXCL_OMP_FLAGS "${OpenMP_CXX_FLAGS}")
+        foreach(item ${OpenMP_CXX_LIBRARIES})
+            set(VEXCL_OMP_FLAGS "${VEXCL_OMP_FLAGS} -l${item}")
+        endforeach()
+	message(STATUS "VEXCL_OMP_FLAGS=${VEXCL_OMP_FLAGS}")
+
+        # Pass the required flags to code
+        target_compile_definitions(JIT INTERFACE VEXCL_OMP_FLAGS="${VEXCL_OMP_FLAGS}")
     endif()
 
     target_link_libraries(JIT INTERFACE Common ${CMAKE_DL_LIBS})

--- a/vexcl/backend/jit/compiler.hpp
+++ b/vexcl/backend/jit/compiler.hpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include <sstream>
 #include <fstream>
 #include <boost/dll/shared_library.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 #include <vexcl/backend/common.hpp>
 #include <vexcl/detail/backtrace.hpp>
@@ -47,12 +48,13 @@ THE SOFTWARE.
 #  endif
 #endif
 
+
 #ifndef VEXCL_JIT_COMPILER_OPTIONS
 #  ifdef _OPENMP
 #    ifdef NDEBUG
-#      define VEXCL_JIT_COMPILER_OPTIONS "-O3 -fPIC -shared -fopenmp"
+#      define VEXCL_JIT_COMPILER_OPTIONS "-O3 -fPIC -shared " BOOST_PP_STRINGIZE(VEXCL_OMP_FLAGS)
 #    else
-#      define VEXCL_JIT_COMPILER_OPTIONS "-g -fPIC -shared -fopenmp"
+#      define VEXCL_JIT_COMPILER_OPTIONS "-g -fPIC -shared " BOOST_PP_STRINGIZE(VEXCL_OMP_FLAGS)
 #    endif
 #  else
 #    ifdef NDEBUG

--- a/vexcl/backend/jit/compiler.hpp
+++ b/vexcl/backend/jit/compiler.hpp
@@ -118,6 +118,7 @@ inline vex::backend::program build_sources(const command_queue &q,
                 << cxxflags << " " << compile_options;
 
         if (0 != system(cmdline.str().c_str()) ) {
+            std::cerr << "Command line: " << cmdline.str() << std::endl;
 #ifndef VEXCL_SHOW_KERNELS
             std::cerr << source << std::endl;
 #endif


### PR DESCRIPTION
This adds support for the new OpenMP discovery on macOS in CMake 3.12. It probably also helps on systems where something else, like `-openmp`, is used instead of `-fopenmp`. I'm getting a warning "unused arguments" from clang, but it's now working in OpenMP mode. (Before this patch, JIT compiling on macOS with `brew install libomp` was broken).

Also bypassing a bug in the MSVC server mode not supporting arbitrary strings in minimum version. Updating max policies to 3.12.