### PR TITLE
Update matrix.hpp

### DIFF
--- a/vexcl/sparse/matrix.hpp
+++ b/vexcl/sparse/matrix.hpp
@@ -33,6 +33,9 @@ class matrix {
             }
         }
 
+        // Dummy matrix
+        matrix() {}
+        
         // Dummy matrix; used internally to pass empty parameters to kernels.
         matrix(const backend::command_queue &q) : q(q) {}
 


### PR DESCRIPTION
Added empty dumme constructor. This is, e.g., needed when vex::sparse::matrix is part of an std::tuple object.