### PR TITLE
Wrap CUtexObject into a struct

### DIFF
--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_CASE(image1d)
 {
     if (!vex::Filter::CC(3, 0)(ctx.device(0))) return;
 
-    VEX_FUNCTION(float, imread, (CUtexObject, tex)(int, i),
+    VEX_FUNCTION(float, imread, (vex::cuda_tex_object, tex)(int, i),
             return tex1Dfetch<float>(tex, i);
             );
 
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(image1d)
 
     vex::vector<float> x(q1, n);
 
-    x = imread(tex, p);
+    x = imread(vex::wrap(tex), p);
 
     check_sample(x, [](size_t, float a) {
             BOOST_CHECK_EQUAL(a, 42);

--- a/vexcl/backend/cuda/texture_object.hpp
+++ b/vexcl/backend/cuda/texture_object.hpp
@@ -37,11 +37,19 @@ THE SOFTWARE.
 
 namespace vex {
 
-namespace traits {                                                             \
-template <> struct is_vector_expr_terminal<CUtexObject> : std::true_type {};
+struct cuda_tex_object {
+    CUtexObject h;
+};
+
+inline cuda_tex_object wrap(CUtexObject h) {
+    return cuda_tex_object{h};
 }
 
-template <> struct type_name_impl<CUtexObject> {
+namespace traits {                                                             \
+template <> struct is_vector_expr_terminal<cuda_tex_object> : std::true_type {};
+}
+
+template <> struct type_name_impl<cuda_tex_object> {
     static std::string get() { return "cudaTextureObject_t"; }
 };
 


### PR DESCRIPTION
It looks like CUtexObject is typedefed to uint64 on Windows,
so in order to get the correct typename in the device code,
the compiler needs help.

Fixes #269.