### PR TITLE
Fix CUDA Linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,6 @@ else()
 
         message(STATUS "Found VexCL::CUDA")
     endif()
-    set(VEXCL_CUDA_FOUND ${CUDAToolkit_FOUND})
 endif()
 
 find_path(Boost_DLL NAMES boost/dll PATHS ${Boost_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,26 +165,31 @@ if (${CMAKE_VERSION} VERSION_LESS 3.17)
     # CUDA availability.
     cmake_policy(SET CMP0146 NEW)
     find_package(CUDA)
-    set(VEXCL_CUDA_FOUND ${CUDA_FOUND})
+    if (CUDA_FOUND)
+        add_library(CUDA INTERFACE)
+        add_library(VexCL::CUDA ALIAS CUDA)
+
+        target_include_directories(CUDA INTERFACE "${CUDA_INCLUDE_DIRS}")
+        target_link_libraries(CUDA INTERFACE Common "${CUDA_CUDA_LIBRARY}")
+        target_compile_definitions(CUDA INTERFACE VEXCL_BACKEND_CUDA)
+
+        message(STATUS "Found VexCL::CUDA")
+    endif()
 else()
     # Check for CUDA availability using FindCUDAToolkit and add
     # support for the CUDA language if it is successful.
     find_package(CUDAToolkit)
     if (CUDAToolkit_FOUND)
         enable_language(CUDA)
+        add_library(CUDA INTERFACE)
+        add_library(VexCL::CUDA ALIAS CUDA)
+
+        target_link_libraries(CUDA INTERFACE Common CUDA::toolkit CUDA::cuda_driver)
+        target_compile_definitions(CUDA INTERFACE VEXCL_BACKEND_CUDA)
+
+        message(STATUS "Found VexCL::CUDA")
     endif()
     set(VEXCL_CUDA_FOUND ${CUDAToolkit_FOUND})
-endif()
-
-if(VEXCL_CUDA_FOUND)
-    add_library(CUDA INTERFACE)
-    add_library(VexCL::CUDA ALIAS CUDA)
-
-    target_include_directories(CUDA INTERFACE "${CUDA_INCLUDE_DIRS}")
-    target_link_libraries(CUDA INTERFACE Common "${CUDA_CUDA_LIBRARY}")
-    target_compile_definitions(CUDA INTERFACE VEXCL_BACKEND_CUDA)
-
-    message(STATUS "Found VexCL::CUDA")
 endif()
 
 find_path(Boost_DLL NAMES boost/dll PATHS ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
This PR is supposed to fix a mistake I made in #296.

When calling [`find_package(CUDAToolkit)`](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html), it imports a set of targets we can link against, instead of setting `CUDA_INCLUDE_DIRS` and `CUDA_CUDA_LIBRARY`.

I only have access to one machine with NVidia GPUs so I'd appreciate it if someone with more CUDA experience than I could take a look, maybe even run some tests. @henryiii perhaps?

